### PR TITLE
dt-bindings: ARM: tegra: Add ASUS Transformers

### DIFF
--- a/Documentation/devicetree/bindings/arm/tegra.yaml
+++ b/Documentation/devicetree/bindings/arm/tegra.yaml
@@ -48,6 +48,15 @@ properties:
           - const: nvidia,cardhu
           - const: nvidia,tegra30
       - items:
+          - const: asus,tf201
+          - const: nvidia,tegra30
+      - items:
+          - const: asus,tf300t
+          - const: nvidia,tegra30
+      - items:
+          - const: asus,tf700t
+          - const: nvidia,tegra30
+      - items:
           - const: toradex,apalis_t30-eval
           - const: toradex,apalis_t30
           - const: nvidia,tegra30


### PR DESCRIPTION
Add a binding for the Tegra30-based ASUS Transformer Series tablet devices. This group includes Transformer Prime TF201, Transformer Pad TF300T and Transformer Infinity TF700T.

Signed-off-by: Svyatoslav Ryhel <clamor95@gmail.com>