### PR TITLE
ARM: tegra: Add device-tree for ASUS Transformer Prime TF201

### DIFF
--- a/arch/arm/boot/dts/Makefile
+++ b/arch/arm/boot/dts/Makefile
@@ -1214,6 +1214,7 @@ dtb-$(CONFIG_ARCH_TEGRA_3x_SOC) += \
 	tegra30-asus-nexus7-grouper-PM269.dtb \
 	tegra30-asus-nexus7-grouper-E1565.dtb \
 	tegra30-asus-nexus7-tilapia-E1565.dtb \
+	tegra30-asus-tf201.dtb \
 	tegra30-asus-tf300t.dtb \
 	tegra30-asus-tf700t.dtb \
 	tegra30-beaver.dtb \

--- a/arch/arm/boot/dts/tegra30-asus-tf201.dts
+++ b/arch/arm/boot/dts/tegra30-asus-tf201.dts
@@ -1,0 +1,718 @@
+// SPDX-License-Identifier: GPL-2.0
+/dts-v1/;
+
+/* This dts file describes the Asus Transformer Prime TF201 tablet */
+/* CPU Speedo ID 3, Soc Speedo ID 2, CPU Process: 1, Core Process: 0 */
+
+#include "tegra30-asus-transformer-common.dtsi"
+
+/ {
+	model = "Asus Transformer Prime TF201";
+	compatible = "asus,tf201", "nvidia,tegra30";
+
+	host1x@50000000 {
+		lcd: dc@54200000 {
+			rgb {
+				status = "okay";
+
+				port@0 {
+					lcd_output: endpoint {
+						remote-endpoint = <&lvds_encoder_input>;
+						bus-width = <24>;
+					};
+				};
+			};
+		};
+
+		hdmi: dc@54240000 { };
+
+		hdmi@54280000 {
+			status = "okay";
+
+			hdmi-supply = <&vdd_5v0_sys>;
+			pll-supply = <&vdd_1v8>;
+			vdd-supply = <&vdd_3v3_sys>;
+
+			nvidia,hpd-gpio = <&gpio TEGRA_GPIO(N, 7) GPIO_ACTIVE_HIGH>;	// hdmi_hpd, in, lo
+			nvidia,ddc-i2c-bus = <&hdmi_ddc>;
+		};
+	};
+
+	pinmux@70000868 {
+		state_default: pinmux {
+			lcd_pwr2_pc6 {
+				nvidia,pins = "lcd_pwr2_pc6",
+						"lcd_dc1_pd2";
+				nvidia,function = "displaya";
+				nvidia,pull = <TEGRA_PIN_PULL_NONE>;
+				nvidia,tristate = <TEGRA_PIN_ENABLE>;
+				nvidia,enable-input = <TEGRA_PIN_ENABLE>;
+			};
+			pbb3 {
+				nvidia,pins = "pbb3";
+				nvidia,function = "vgp3";
+				nvidia,pull = <TEGRA_PIN_PULL_NONE>;
+				nvidia,tristate = <TEGRA_PIN_DISABLE>;
+				nvidia,enable-input = <TEGRA_PIN_ENABLE>;
+			};
+			pbb7 {
+				nvidia,pins = "pbb7";
+				nvidia,function = "i2s4";
+				nvidia,pull = <TEGRA_PIN_PULL_NONE>;
+				nvidia,tristate = <TEGRA_PIN_DISABLE>;
+				nvidia,enable-input = <TEGRA_PIN_ENABLE>;
+			};
+			kb_col4_pq4 {
+				nvidia,pins = "kb_row7_pr7";
+				nvidia,function = "kbc";
+				nvidia,pull = <TEGRA_PIN_PULL_UP>;
+				nvidia,tristate = <TEGRA_PIN_ENABLE>;
+				nvidia,enable-input = <TEGRA_PIN_ENABLE>;
+			};
+		};
+	};
+
+	uartc: serial@70006200 {
+		compatible = "nvidia,tegra30-hsuart";
+		status = "okay";
+
+		nvidia,adjust-baud-rates = <0 9600 100>,
+					   <9600 115200 200>,
+					   <1000000 4000000 136>;
+
+		/* Azurewave AW-NH615 BCM4329B1 */
+		bluetooth {
+			compatible = "brcm,bcm4329-bt";
+
+			max-speed = <4000000>;
+
+			clocks = <&tegra_pmc TEGRA_PMC_CLK_BLINK>;
+			clock-names = "txco";
+
+			vbat-supply  = <&vdd_3v3_sys>;
+			vddio-supply = <&vdd_1v8>;
+
+			device-wakeup-gpios = <&gpio TEGRA_GPIO(U, 1) GPIO_ACTIVE_HIGH>;	/* bt_ext_wake, out, lo	*/
+			host-wakeup-gpios =   <&gpio TEGRA_GPIO(U, 6) IRQ_TYPE_LEVEL_LOW>;	/* bt_host_wake, in, lo	*/
+			shutdown-gpios =      <&gpio TEGRA_GPIO(U, 0) GPIO_ACTIVE_LOW>;		/* bcm4329_nshutdown_gp, out, lo */
+		};
+	};
+
+	i2c@7000c400 {		/*i2c2*/
+		/* Atmel MXT768E touchscreen */
+		touchscreen@4d {
+			compatible = "atmel,maxtouch";
+			reg = <0x4d>;
+
+			interrupt-parent = <&gpio>;
+			interrupts = <TEGRA_GPIO(H, 4) IRQ_TYPE_EDGE_FALLING>;		/* touch_irq, in, hi */
+			reset-gpios = <&gpio TEGRA_GPIO(H, 6) GPIO_ACTIVE_LOW>;		/* touch_reset, out, hi */
+
+			avdd-supply = <&vdd_3v3_sys>;
+			vdd-supply  = <&vdd_3v3_sys>;
+		};
+	};
+
+	i2c@7000c500 {		/*i2c3*/
+		clock-frequency = <100000>;
+
+		/* Rear camera Fujitsu MBG048 image processor */
+		back_camera: camera@1f {
+			compatible = "fujitsu,m6mo";
+			reg = <0x1f>;
+
+			reset-gpios = <&gpio TEGRA_GPIO(BB, 0) GPIO_ACTIVE_LOW>; 	// cam_sensor_rst_lo, out, lo
+		};
+
+		front_camera: camera@48 {
+			compatible = "aptina,mi1040";
+			reg = <0x48>;
+
+			clocks = <>; 						// <&tegra_car TEGRA30_CLK_PLL_A>; CAM_MCLK
+			clock-names = "extclk";
+
+			vddio-suppy = <&vdd_1v8>;
+			vdda-suppy = <&vdd_3v3_sys>;			// 2.85V?
+			vddc-supply = <&cam_vddc>;			// PWR_DN
+
+			reset-gpios = <&gpio TEGRA_GPIO(O, 0) GPIO_ACTIVE_LOW>;
+		};
+
+		gyro@68 {
+			compatible = "invensense,mpu3050";
+			reg = <0x68>;
+			interrupt-parent = <&gpio>;
+			interrupts = <TEGRA_GPIO(X, 1) IRQ_TYPE_EDGE_RISING>;		// mpu3050, in, lo
+			mount-matrix = "0", "-1", "0", "-1", "0", "0", "0", "0", "-1";
+			accel-slave = <&accel>;
+			compass-slave = <&compass>;
+
+			i2c-gate {
+				#address-cells = <1>;
+				#size-cells = <0>;
+
+				accel: accel@f {
+					compatible = "kionix,kxtf9";
+					reg = <0x0f>;
+					interrupt-parent = <&gpio>;
+					interrupts = <TEGRA_GPIO(O, 5) IRQ_TYPE_EDGE_RISING>;	// kxtf9, in, lo
+					mount-matrix = "-1", "0", "0", "0", "1", "0", "0", "0", "-1";
+				};
+
+				compass: compass@e {
+					compatible = "aichi,ami306";
+					reg = <0x0e>;
+					interrupt-parent = <&gpio>;
+					interrupts = <TEGRA_GPIO(W, 0) IRQ_TYPE_EDGE_RISING>;	// compassirq
+					mount-matrix = "-1", "0", "0", "0", "-1", "0", "0", "0", "-1";
+				};
+			};
+		};
+	};
+
+	i2c@7000d000 {		/*i2c5*/
+		/* Realtek ALC5631 audio codec */
+		rt5631: rt5631@1a {
+			compatible = "realtek,rt5631";
+			reg = <0x1a>;
+
+			realtek,dmic1-data-pin = <1>;
+		};
+	};
+
+	/* internal SDIO WiFi */
+	sdhci@78000400 {		/* sdmmc3 */
+		/* Azurewave AW-NH615 BCM4329 */
+		wifi@1 {
+			reg = <1>;
+			compatible = "brcm,bcm4329-fmac";
+			interrupt-parent = <&gpio>;
+			interrupts = <TEGRA_GPIO(O, 4) IRQ_TYPE_LEVEL_HIGH>;	/* bcmsdh_sdmmc, in, lo */
+			interrupt-names = "host-wake";
+		};
+	};
+
+	/* HannStar HSD101PWW2 Rev0-A00/A01 LCD SuperIPS+ HD panel */
+	display-panel {
+		compatible = "hannstar,hsd070pww1", "panel-lvds";
+
+		power-supply = <&vdd_pnl>;
+		backlight = <&backlight_lvds>;
+
+		width-mm = <136>;			/* hsd101pww2 panel has same properties as */
+		height-mm = <217>;			/* hsd070pww1, only difference is physical size */
+
+		data-mapping = "jeida-24";
+
+		port {
+			panel_input: endpoint {
+				remote-endpoint = <&lvds_encoder_output>;
+			};
+		};
+	};
+
+	/* Texas Instruments SN75LVDS83B LVDS Transmitter */
+	/* NOTE: datasheet also mentions about THine TH133B LVDS Transmitter */
+	lvds-encoder {
+		compatible = "ti,sn75lvds83", "lvds-encoder";
+
+		powerdown-gpios = <&gpio TEGRA_GPIO(N, 6) GPIO_ACTIVE_LOW>;
+
+		ports {
+			#address-cells = <1>;
+			#size-cells = <0>;
+
+			port@0 {
+				reg = <0>;
+
+				lvds_encoder_input: endpoint {
+					remote-endpoint = <&lcd_output>;
+				};
+			};
+
+			port@1 {
+				reg = <1>;
+
+				lvds_encoder_output: endpoint {
+					remote-endpoint = <&panel_input>;
+				};
+			};
+		};
+	};
+
+	vibrator {
+		compatible = "gpio-vibrator";
+		enable-gpios = <&gpio TEGRA_GPIO(H, 7) GPIO_ACTIVE_HIGH>;
+		vcc-supply = <&vdd_3v3_sys>;
+	};
+
+	sound {
+		compatible = "nvidia,tegra-audio-rt5631-tf201",
+			     "nvidia,tegra-audio-rt5631";
+		nvidia,model = "ASUS Transformer Prime TF201 ALC5631";
+
+		nvidia,audio-routing =
+			"Headphone Jack", "HPOL",
+			"Headphone Jack", "HPOR",
+			"Int Spk", "SPOL",
+			"Int Spk", "SPOR",
+			"MIC1", "Mic Bias1",
+			"Mic Bias1", "Mic Jack",
+			"DMIC", "Int Mic";
+
+		nvidia,i2s-controller = <&tegra_i2s1>;
+		nvidia,audio-codec = <&rt5631>;
+
+		nvidia,hp-det-gpios = <&gpio TEGRA_GPIO(W, 2) GPIO_ACTIVE_LOW>;
+
+		clocks = <&tegra_car TEGRA30_CLK_PLL_A>,
+			 <&tegra_car TEGRA30_CLK_PLL_A_OUT0>,
+			 <&tegra_car TEGRA30_CLK_EXTERN1>;
+		clock-names = "pll_a", "pll_a_out0", "mclk";
+
+		assigned-clocks = <&tegra_car TEGRA30_CLK_EXTERN1>,
+				  <&tegra_pmc TEGRA_PMC_CLK_OUT_1>;
+
+		assigned-clock-parents = <&tegra_car TEGRA30_CLK_PLL_A_OUT0>,
+					 <&tegra_car TEGRA30_CLK_EXTERN1>;
+	};
+
+	memory-controller@7000f000 {
+		emc-timings-0 {
+			/* EMEM timings are common */
+			timing-25500000 {
+				clock-frequency = <25500000>;
+
+				nvidia,emem-configuration = < 0x00020001 0x80000010
+						0x00000001 0x00000001 0x00000002 0x00000000
+						0x00000003 0x00000001 0x00000002 0x00000004
+						0x00000001 0x00000000 0x00000002 0x00000002
+						0x02020001 0x00060402 0x73e30303 0x001f0000 >;
+			};
+
+			timing-51000000 {
+				clock-frequency = <51000000>;
+
+				nvidia,emem-configuration = < 0x00010001 0x80000010
+						0x00000001 0x00000001 0x00000002 0x00000000
+						0x00000003 0x00000001 0x00000002 0x00000004
+						0x00000001 0x00000000 0x00000002 0x00000002
+						0x02020001 0x00060402 0x72c30303 0x001f0000 >;
+			};
+
+			timing-102000000 {
+				clock-frequency = <102000000>;
+
+				nvidia,emem-configuration = < 0x00000001 0x80000018
+						0x00000001 0x00000001 0x00000003 0x00000001
+						0x00000003 0x00000001 0x00000002 0x00000004
+						0x00000001 0x00000000 0x00000002 0x00000002
+						0x02020001 0x00060403 0x72430504 0x001f0000 >;
+			};
+
+			timing-204000000 {
+				clock-frequency = <204000000>;
+
+				nvidia,emem-configuration = < 0x00000003 0x80000025
+						0x00000001 0x00000001 0x00000006 0x00000003
+						0x00000005 0x00000001 0x00000002 0x00000004
+						0x00000001 0x00000000 0x00000003 0x00000002
+						0x02030001 0x00070506 0x71e40a07 0x001f0000 >;
+			};
+
+/*
+			nvidia,ram-code = <0>; /* Elpida 1GB EDB8132B2MA-8D-F lpDDR2 */
+			timing-400000000 {
+				clock-frequency = <400000000>;
+
+				nvidia,emem-configuration = < 0x00000006 0x80000048
+						0x00000002 0x00000003 0x0000000c 0x00000007
+						0x00000009 0x00000001 0x00000002 0x00000006
+						0x00000001 0x00000000 0x00000004 0x00000004
+						0x04040001 0x000d090c 0x71c6120d 0x001f0000 >;
+			};
+*/
+
+			nvidia,ram-code = <2>; /* Unknown vendor lpDDR2 500MHz */
+			timing-500000000 {
+				clock-frequency = <500000000>;
+
+				nvidia,emem-configuration = < 0x00000007 0x8000005a
+						0x00000003 0x00000004 0x0000000e 0x00000009
+						0x0000000c 0x00000002 0x00000002 0x00000008
+						0x00000001 0x00000000 0x00000004 0x00000005
+						0x05040001 0x00100a0e 0x71c8170f 0x001f0000 >;
+			};
+		};
+	};
+
+	memory-controller@7000f400 {
+		emc-timings-0 {
+			/* Rev 3.1 with max frequency 400 MHz */
+			nvidia,ram-code = <0>; /* Elpida 1GB EDB8132B2MA-8D-F lpDDR2 */
+
+			timing-25500000 {
+				clock-frequency = <25500000>;
+
+				nvidia,emc-auto-cal-interval = <0x001fffff>;
+				nvidia,emc-mode-1 = <0x00010022>;
+				nvidia,emc-mode-2 = <0x00020001>;
+				nvidia,emc-mode-reset = <0x00000000>;
+				nvidia,emc-zcal-cnt-long = <0x00000009>;
+				nvidia,emc-cfg-dyn-self-ref;
+				nvidia,emc-cfg-periodic-qrst;
+
+				nvidia,emc-configuration =  < 0x00000001 
+						0x00000003 0x00000002 0x00000002 0x00000004
+						0x00000004 0x00000001 0x00000005 0x00000002
+						0x00000002 0x00000001 0x00000001 0x00000000
+						0x00000001 0x00000003 0x00000001 0x0000000b
+						0x0000000a 0x00000060 0x00000000 0x00000018
+						0x00000001 0x00000001 0x00000002 0x00000000
+						0x00000001 0x00000007 0x00000004 0x00000004
+						0x00000003 0x00000008 0x00000004 0x00000004
+						0x00000002 0x0000006b 0x00000004 0x00000004
+						0x00000000 0x00000000 0x00004282 0x00780084
+						0x00008000 0x00098000 0x00098000 0x00098000
+						0x00098000 0x00000010 0x00000010 0x00000010
+						0x00000010 0x00000000 0x00000000 0x00000000
+						0x00000000 0x00000008 0x00000008 0x00000008
+						0x00000008 0x00000000 0x00000000 0x00000000
+						0x00000000 0x00000000 0x00000000 0x00000000
+						0x00000000 0x00080000 0x00080000 0x00080000
+						0x00080000 0x00100220 0x0800201c 0x00000000
+						0x77ffc004 0x01f1f008 0x00000000 0x00000007
+						0x08000068 0x08000000 0x00000802 0x00000000
+						0x00000009 0x00090009 0xa0f10000 0x00000000
+						0x00000000 0x800001c5 0xe0000000 0xff00ff00 >;
+			};
+
+			timing-51000000 {
+				clock-frequency = <51000000>;
+
+				nvidia,emc-auto-cal-interval = <0x001fffff>;
+				nvidia,emc-mode-1 = <0x00010022>;
+				nvidia,emc-mode-2 = <0x00020001>;
+				nvidia,emc-mode-reset = <0x00000000>;
+				nvidia,emc-zcal-cnt-long = <0x00000009>;
+				nvidia,emc-cfg-dyn-self-ref;
+				nvidia,emc-cfg-periodic-qrst;
+
+				nvidia,emc-configuration =  < 0x00000003
+						0x00000006 0x00000002 0x00000002 0x00000004
+						0x00000004 0x00000001 0x00000005 0x00000002
+						0x00000002 0x00000001 0x00000001 0x00000000
+						0x00000001 0x00000003 0x00000001 0x0000000b
+						0x0000000a 0x000000c0 0x00000000 0x00000030
+						0x00000001 0x00000001 0x00000002 0x00000000
+						0x00000001 0x00000007 0x00000008 0x00000008
+						0x00000003 0x00000008 0x00000004 0x00000004
+						0x00000002 0x000000d5 0x00000004 0x00000004
+						0x00000000 0x00000000 0x00004282 0x00780084
+						0x00008000 0x00098000 0x00098000 0x00098000
+						0x00098000 0x00000010 0x00000010 0x00000010
+						0x00000010 0x00000000 0x00000000 0x00000000
+						0x00000000 0x00000018 0x00000018 0x00000018
+						0x00000018 0x00000000 0x00000000 0x00000000
+						0x00000000 0x00000000 0x00000000 0x00000000
+						0x00000000 0x00080000 0x00080000 0x00080000
+						0x00080000 0x00100220 0x0800201c 0x00000000
+						0x77ffc004 0x01f1f008 0x00000000 0x00000007
+						0x08000068 0x08000000 0x00000802 0x00000000
+						0x00000009 0x00090009 0xa0f10000 0x00000000
+						0x00000000 0x80000287 0xe0000000 0xff00ff00 >;
+			};
+
+			timing-102000000 {
+				clock-frequency = <102000000>;
+
+				nvidia,emc-auto-cal-interval = <0x001fffff>;
+				nvidia,emc-mode-1 = <0x00010022>;
+				nvidia,emc-mode-2 = <0x00020001>;
+				nvidia,emc-mode-reset = <0x00000000>;
+				nvidia,emc-zcal-cnt-long = <0x0000000a>;
+				nvidia,emc-cfg-dyn-self-ref;
+				nvidia,emc-cfg-periodic-qrst;
+
+				nvidia,emc-configuration =  < 0x00000006
+						0x0000000d 0x00000004 0x00000002 0x00000004
+						0x00000004 0x00000001 0x00000005 0x00000002
+						0x00000002 0x00000001 0x00000001 0x00000000
+						0x00000001 0x00000003 0x00000001 0x0000000b
+						0x0000000a 0x00000181 0x00000000 0x00000060
+						0x00000001 0x00000001 0x00000002 0x00000000
+						0x00000001 0x00000007 0x0000000f 0x0000000f
+						0x00000003 0x00000008 0x00000004 0x00000004
+						0x00000002 0x000001a9 0x00000004 0x00000006
+						0x00000000 0x00000000 0x00004282 0x00780084
+						0x00008000 0x000a0000 0x000a0000 0x000a0000
+						0x000a0000 0x00000010 0x00000010 0x00000010
+						0x00000010 0x00000000 0x00000000 0x00000000
+						0x00000000 0x00000008 0x00000008 0x00000008
+						0x00000008 0x00000000 0x00000000 0x00000000
+						0x00000000 0x00000000 0x00000000 0x00000000
+						0x00000000 0x00080000 0x00080000 0x00080000
+						0x00080000 0x00120220 0x0800201c 0x00000000
+						0x77ffc004 0x01f1f008 0x00000000 0x00000007
+						0x08000068 0x08000000 0x00000802 0x00000000
+						0x0000000a 0x00090009 0xa0f10000 0x00000000
+						0x00000000 0x8000040b 0xe0000000 0xff00ff00 >;
+			};
+
+			timing-204000000 {
+				clock-frequency = <204000000>;
+
+				nvidia,emc-auto-cal-interval = <0x001fffff>;
+				nvidia,emc-mode-1 = <0x00010042>;
+				nvidia,emc-mode-2 = <0x00020001>;
+				nvidia,emc-mode-reset = <0x00000000>;
+				nvidia,emc-zcal-cnt-long = <0x00000013>;
+				nvidia,emc-cfg-dyn-self-ref;
+				nvidia,emc-cfg-periodic-qrst;
+
+				nvidia,emc-configuration =  < 0x0000000c
+						0x0000001a 0x00000008 0x00000003 0x00000005
+						0x00000004 0x00000001 0x00000006 0x00000003
+						0x00000003 0x00000002 0x00000002 0x00000000
+						0x00000001 0x00000003 0x00000001 0x0000000c
+						0x0000000a 0x00000303 0x00000000 0x000000c0
+						0x00000001 0x00000001 0x00000003 0x00000000
+						0x00000001 0x00000007 0x0000001d 0x0000001d
+						0x00000004 0x0000000b 0x00000005 0x00000004
+						0x00000002 0x00000351 0x00000004 0x00000006
+						0x00000000 0x00000000 0x00004282 0x00440084
+						0x00008000 0x00074000 0x00074000 0x00074000
+						0x00074000 0x00000010 0x00000010 0x00000010
+						0x00000010 0x00000000 0x00000000 0x00000000
+						0x00000000 0x00000018 0x00000018 0x00000018
+						0x00000018 0x00000000 0x00000000 0x00000000
+						0x00000000 0x00000000 0x00000000 0x00000000
+						0x00000000 0x00078000 0x00078000 0x00078000
+						0x00078000 0x00100220 0x0800201c 0x00000000
+						0x77ffc004 0x01f1f008 0x00000000 0x00000007
+						0x08000068 0x08000000 0x00000802 0x00000000
+						0x00000013 0x00090009 0xa0f10000 0x00000000
+						0x00000000 0x80000713 0xe0000000 0xff00ff00 >;
+			};
+
+			timing-400000000 {
+				clock-frequency = <400000000>;
+
+				nvidia,emc-auto-cal-interval = <0x001fffff>;
+				nvidia,emc-mode-1 = <0x00010082>;
+				nvidia,emc-mode-2 = <0x00020004>;
+				nvidia,emc-mode-reset = <0x00000000>;
+				nvidia,emc-zcal-cnt-long = <0x00000024>;
+
+				nvidia,emc-configuration =  < 0x00000017
+						0x00000033 0x00000010 0x00000007 0x00000007
+						0x00000007 0x00000002 0x0000000a 0x00000007
+						0x00000007 0x00000003 0x00000002 0x00000000
+						0x00000003 0x00000007 0x00000004 0x0000000d
+						0x0000000e 0x000005e9 0x00000000 0x0000017a
+						0x00000002 0x00000002 0x00000007 0x00000000
+						0x00000001 0x0000000c 0x00000038 0x00000038
+						0x00000006 0x00000014 0x00000009 0x00000004
+						0x00000002 0x00000680 0x00000000 0x00000006
+						0x00000000 0x00000000 0x00006282 0x001d0084
+						0x00008000 0x0002c000 0x0002c000 0x0002c000
+						0x0002c000 0x00000010 0x00000010 0x00000010
+						0x00000010 0x00000000 0x00000000 0x00000000
+						0x00000000 0x00000008 0x00000008 0x00000008
+						0x00000008 0x00000000 0x00000000 0x00000000
+						0x00000000 0x00000000 0x00000000 0x00000000
+						0x00000000 0x00048000 0x00048000 0x00048000
+						0x00048000 0x000c0220 0x0800003d 0x00000000
+						0x77ffc004 0x01f1f408 0x00000000 0x00000007
+						0x08000068 0x08000000 0x00000802 0x00000000
+						0x00000024 0x000c000c 0xa0f10000 0x00000000
+						0x00000000 0x80000ce6 0xe0000000 0xff00ff88 >;
+			};
+		};
+
+		emc-timings-2 {
+			/* Rev 3.2 with max frequency 500 MHz */
+			nvidia,ram-code = <2>; /* Unknown vendor */
+
+			timing-25500000 {
+				clock-frequency = <25500000>;
+
+				nvidia,emc-auto-cal-interval = <0x001fffff>;
+				nvidia,emc-mode-1 = <0x00010022>;
+				nvidia,emc-mode-2 = <0x00020001>;
+				nvidia,emc-mode-reset = <0x00000000>;
+				nvidia,emc-zcal-cnt-long = <0x00000009>;
+				nvidia,emc-cfg-dyn-self-ref;
+				nvidia,emc-cfg-periodic-qrst;
+
+				nvidia,emc-configuration =  < 0x00000001 
+						0x00000003 0x00000002 0x00000002 0x00000004
+						0x00000004 0x00000001 0x00000005 0x00000002
+						0x00000002 0x00000001 0x00000001 0x00000000
+						0x00000001 0x00000003 0x00000001 0x0000000b
+						0x00000009 0x00000060 0x00000000 0x00000018
+						0x00000001 0x00000001 0x00000002 0x00000000
+						0x00000001 0x00000007 0x00000004 0x00000004
+						0x00000003 0x00000008 0x00000004 0x00000004
+						0x00000002 0x0000006b 0x00000004 0x00000004
+						0x00000000 0x00000000 0x00004282 0x00780084
+						0x00008000 0x000fc000 0x000fc000 0x000fc000
+						0x000fc000 0x000fc000 0x000fc000 0x000fc000
+						0x000fc000 0x00000000 0x00000000 0x00000000
+						0x00000000 0x00000000 0x00000000 0x00000000
+						0x00000000 0x00000000 0x00000000 0x00000000
+						0x00000000 0x00000000 0x00000000 0x00000000
+						0x00000000 0x000fc000 0x000fc000 0x000fc000
+						0x000fc000 0x00100220 0x0800201c 0x00000000
+						0x77ffc004 0x01f1f008 0x00000000 0x00000007
+						0x08000068 0x08000000 0x00000802 0x00064000
+						0x0000000a 0x00090009 0xa0f10000 0x00000000
+						0x00000000 0x800001c5 0xe0000000 0xff00ff00 >;
+			};
+
+			timing-51000000 {
+				clock-frequency = <51000000>;
+
+				nvidia,emc-auto-cal-interval = <0x001fffff>;
+				nvidia,emc-mode-1 = <0x00010022>;
+				nvidia,emc-mode-2 = <0x00020001>;
+				nvidia,emc-mode-reset = <0x00000000>;
+				nvidia,emc-zcal-cnt-long = <0x00000009>;
+				nvidia,emc-cfg-dyn-self-ref;
+				nvidia,emc-cfg-periodic-qrst;
+
+				nvidia,emc-configuration =  < 0x00000003
+						0x00000006 0x00000002 0x00000002 0x00000004
+						0x00000004 0x00000001 0x00000005 0x00000002
+						0x00000002 0x00000001 0x00000001 0x00000000
+						0x00000001 0x00000003 0x00000001 0x0000000b
+						0x00000009 0x000000c0 0x00000000 0x00000030
+						0x00000001 0x00000001 0x00000002 0x00000000
+						0x00000001 0x00000007 0x00000008 0x00000008
+						0x00000003 0x00000008 0x00000004 0x00000004
+						0x00000002 0x000000d5 0x00000004 0x00000004
+						0x00000000 0x00000000 0x00004282 0x00780084
+						0x00008000 0x000fc000 0x000fc000 0x000fc000
+						0x000fc000 0x000fc000 0x000fc000 0x000fc000
+						0x000fc000 0x00000000 0x00000000 0x00000000
+						0x00000000 0x00000000 0x00000000 0x00000000
+						0x00000000 0x00000000 0x00000000 0x00000000
+						0x00000000 0x00000000 0x00000000 0x00000000
+						0x00000000 0x000fc000 0x000fc000 0x000fc000
+						0x000fc000 0x00100220 0x0800201c 0x00000000
+						0x77ffc004 0x01f1f008 0x00000000 0x00000007
+						0x08000068 0x08000000 0x00000802 0x00064000
+						0x00000013 0x00090009 0xa0f10000 0x00000000
+						0x00000000 0x80000287 0xe0000000 0xff00ff00 >;
+			};
+
+			timing-102000000 {
+				clock-frequency = <102000000>;
+
+				nvidia,emc-auto-cal-interval = <0x001fffff>;
+				nvidia,emc-mode-1 = <0x00010022>;
+				nvidia,emc-mode-2 = <0x00020001>;
+				nvidia,emc-mode-reset = <0x00000000>;
+				nvidia,emc-zcal-cnt-long = <0x0000000a>;
+				nvidia,emc-cfg-dyn-self-ref;
+				nvidia,emc-cfg-periodic-qrst;
+
+				nvidia,emc-configuration =  < 0x00000006
+						0x0000000d 0x00000004 0x00000002 0x00000004
+						0x00000004 0x00000001 0x00000005 0x00000002
+						0x00000002 0x00000001 0x00000001 0x00000000
+						0x00000001 0x00000003 0x00000001 0x0000000b
+						0x00000009 0x00000181 0x00000000 0x00000060
+						0x00000001 0x00000001 0x00000002 0x00000000
+						0x00000001 0x00000007 0x0000000f 0x0000000f
+						0x00000003 0x00000008 0x00000004 0x00000004
+						0x00000002 0x000001a9 0x00000004 0x00000004
+						0x00000000 0x00000000 0x00004282 0x00780084
+						0x00008000 0x000fc000 0x000fc000 0x000fc000
+						0x000fc000 0x000fc000 0x000fc000 0x000fc000
+						0x000fc000 0x00000000 0x00000000 0x00000000
+						0x00000000 0x00000000 0x00000000 0x00000000
+						0x00000000 0x00000000 0x00000000 0x00000000
+						0x00000000 0x00000000 0x00000000 0x00000000
+						0x00000000 0x000fc000 0x000fc000 0x000fc000
+						0x000fc000 0x00100220 0x0800201c 0x00000000
+						0x77ffc004 0x01f1f008 0x00000000 0x00000007
+						0x08000068 0x08000000 0x00000802 0x00064000
+						0x00000025 0x00090009 0xa0f10000 0x00000000
+						0x00000000 0x8000040b 0xe0000000 0xff00ff00 >;
+			};
+
+			timing-204000000 {
+				clock-frequency = <204000000>;
+
+				nvidia,emc-auto-cal-interval = <0x001fffff>;
+				nvidia,emc-mode-1 = <0x00010042>;
+				nvidia,emc-mode-2 = <0x00020001>;
+				nvidia,emc-mode-reset = <0x00000000>;
+				nvidia,emc-zcal-cnt-long = <0x00000013>;
+				nvidia,emc-cfg-dyn-self-ref;
+				nvidia,emc-cfg-periodic-qrst;
+
+				nvidia,emc-configuration =  < 0x0000000c
+						0x0000001a 0x00000008 0x00000003 0x00000005
+						0x00000004 0x00000001 0x00000006 0x00000003
+						0x00000003 0x00000002 0x00000002 0x00000000
+						0x00000001 0x00000003 0x00000001 0x0000000c
+						0x0000000a 0x00000303 0x00000000 0x000000c0
+						0x00000001 0x00000001 0x00000003 0x00000000
+						0x00000001 0x00000007 0x0000001d 0x0000001d
+						0x00000004 0x0000000b 0x00000005 0x00000004
+						0x00000002 0x00000351 0x00000004 0x00000006
+						0x00000000 0x00000000 0x00004282 0x00440084
+						0x00008000 0x00060000 0x00060000 0x00060000
+						0x00060000 0x00072000 0x00072000 0x00072000
+						0x00072000 0x00000000 0x00000000 0x00000000
+						0x00000000 0x00000000 0x00000000 0x00000000
+						0x00000000 0x00000000 0x00000000 0x00000000
+						0x00000000 0x00000000 0x00000000 0x00000000
+						0x00000000 0x000d0000 0x000d0000 0x000d0000
+						0x000d0000 0x000e0220 0x0800201c 0x00000000
+						0x77ffc004 0x01f1f008 0x00000000 0x00000007
+						0x08000068 0x08000000 0x00000802 0x00064000
+						0x0000004a 0x00090009 0xa0f10000 0x00000000
+						0x00000000 0x80000713 0xe0000000 0xff00ff00 >;
+			};
+
+			timing-500000000 {
+				clock-frequency = <500000000>;
+
+				nvidia,emc-auto-cal-interval = <0x001fffff>;
+				nvidia,emc-mode-1 = <0x00010042>;
+				nvidia,emc-mode-2 = <0x00020001>;
+				nvidia,emc-mode-reset = <0x00000000>;
+				nvidia,emc-zcal-cnt-long = <0x0000002d>;
+				nvidia,emc-cfg-dyn-self-ref;
+				nvidia,emc-cfg-periodic-qrst;
+
+				nvidia,emc-configuration =  < 0x0000001d 
+						0x00000040 0x00000014 0x00000008 0x00000007
+						0x00000009 0x00000003 0x0000000d 0x00000008
+						0x00000008 0x00000004 0x00000002 0x00000000
+						0x00000004 0x00000008 0x00000005 0x0000000d
+						0x0000000f 0x00000763 0x00000000 0x000001d8
+						0x00000003 0x00000003 0x00000008 0x00000000
+						0x00000001 0x0000000e 0x00000046 0x00000046
+						0x00000008 0x00000019 0x0000000b 0x00000004
+						0x00000002 0x00000820 0x00000000 0x00000006
+						0x00000000 0x00000000 0x00006282 0xf0140091
+						0x00008000 0x00000008 0x00000008 0x00000008
+						0x00000008 0x0000000a 0x0000000a 0x0000000a
+						0x0000000a 0x00000000 0x00000000 0x00000000
+						0x00000000 0x00000000 0x00000000 0x00000000
+						0x00000000 0x00000000 0x00000000 0x00000000
+						0x00000000 0x00000000 0x00000000 0x00000000
+						0x00000000 0x0000000c 0x0000000c 0x0000000c
+						0x0000000c 0x00080220 0x0800003d 0x00000000
+						0x77ffc004 0x01f1f408 0x00000000 0x00000007
+						0x08000068 0x08000000 0x00000802 0x00064000
+						0x000000b4 0x000d000d 0xa0f10404 0x00000000
+						0x00000000 0x80000fde 0xe0000000 0xff00ff88 >;
+			};
+		};
+	};
+};

--- a/arch/arm/boot/dts/tegra30-asus-transformer-common.dtsi
+++ b/arch/arm/boot/dts/tegra30-asus-transformer-common.dtsi
@@ -1,0 +1,1443 @@
+// SPDX-License-Identifier: GPL-2.0
+
+/* This dtsi file describes parts common for all T30 Transformers from Asus */
+
+#include <dt-bindings/input/gpio-keys.h>
+#include <dt-bindings/input/input.h>
+#include <dt-bindings/thermal/thermal.h>
+
+#include "tegra30.dtsi"
+#include "tegra30-cpu-opp.dtsi"
+#include "tegra30-cpu-opp-microvolt.dtsi"
+
+/ {
+	aliases {
+		rtc0 = &pmic;
+		rtc1 = "/rtc@7000e000";
+
+		display0 = &lcd;
+		display1 = &hdmi;
+
+		serial0 = &uartd; /* reserved: console */
+		serial1 = &uartc; /* Bluetooth */
+		serial2 = &uartb; /* GPS */
+	};
+
+	/*
+	 * The decompressor and also some bootloaders rely on a
+	 * pre-existing /chosen node to be available to insert the
+	 * command line and merge other ATAGS info.
+	 */
+	chosen {};
+
+	memory@80000000 {
+		reg = <0x80000000 0x40000000>;
+	};
+
+	reserved-memory {
+		#address-cells = <1>;
+		#size-cells = <1>;
+		ranges;
+
+		linux,cma@80000000 {
+			compatible = "shared-dma-pool";
+			alloc-ranges = <0x80000000 0x30000000>;
+			size = <0x10000000>; /* 256MiB */
+			linux,cma-default;
+			reusable;
+		};
+
+		ramoops@beb00000 {
+			compatible = "ramoops";
+			reg = <0xbeb00000 0x10000>;	/* 64kB */
+			console-size = <0x8000>;	/* 32kB */
+			record-size = <0x400>;		/*  1kB */
+			ecc-size = <16>;
+		};
+
+		framebuffer@abc01000 {
+			reg = <0xabc01000 0x3e9000>;
+			no-map;
+		};
+
+		lp0_vec@bddf9000 {
+			reg = <0xbddf9000 0x2000>;	// passed from bootloader (ATAGS/NVIDIA, cmdline)
+		};
+
+		trustzone@bfe00000 {
+			// used by TF firmware
+			reg = <0xbfe00000 0x200000>;	/* 2MB */
+			no-map;
+		};
+	};
+
+	gpio@6000d000 {
+		usb_charge_limit {
+			gpio-hog;
+			gpios = <TEGRA_GPIO(R, 1) GPIO_ACTIVE_LOW>;	// LIMIT_SET0, out, lo; @tegra_udc.LIMIT_PWR [0 = 0.5A, 1 = 1A]
+			output-high;
+		};
+	};
+
+	pinmux@70000868 {
+		pinctrl-names = "default";
+		pinctrl-0 = <&state_default>;
+
+		state_default: pinmux {
+			/* SDMMC1 pinmux */
+			sdmmc1_clk_pz0 {
+				nvidia,pins = "sdmmc1_clk_pz0";
+				nvidia,function = "sdmmc1";	
+				nvidia,pull = <TEGRA_PIN_PULL_NONE>;
+				nvidia,tristate = <TEGRA_PIN_DISABLE>;
+				nvidia,enable-input = <TEGRA_PIN_ENABLE>;
+			};
+			sdmmc1_cmd_pz1 {
+				nvidia,pins = "sdmmc1_cmd_pz1",
+						"sdmmc1_dat3_py4",
+						"sdmmc1_dat2_py5",
+						"sdmmc1_dat1_py6",
+						"sdmmc1_dat0_py7";
+				nvidia,function = "sdmmc1";	
+				nvidia,pull = <TEGRA_PIN_PULL_UP>;
+				nvidia,tristate = <TEGRA_PIN_DISABLE>;
+				nvidia,enable-input = <TEGRA_PIN_ENABLE>;
+			};
+
+			/* SDMMC3 pinmux */
+			vi_d1_pd5 {
+				nvidia,pins = "vi_d1_pd5",
+						"vi_d2_pl0",
+						"vi_d3_pl1",
+						"vi_d5_pl3",
+						"vi_d7_pl5";
+				nvidia,function = "sdmmc2";	
+				nvidia,pull = <TEGRA_PIN_PULL_NONE>;
+				nvidia,tristate = <TEGRA_PIN_DISABLE>;
+				nvidia,enable-input = <TEGRA_PIN_ENABLE>;
+			};
+			vi_d8_pl6 {
+				nvidia,pins = "vi_d8_pl6",
+						"vi_d9_pl7";
+				nvidia,function = "sdmmc2";	
+				nvidia,pull = <TEGRA_PIN_PULL_NONE>;
+				nvidia,tristate = <TEGRA_PIN_DISABLE>;
+				nvidia,enable-input = <TEGRA_PIN_ENABLE>;
+			};
+
+			/* SDMMC3 pinmux */
+			sdmmc3_clk_pa6 {
+				nvidia,pins = "sdmmc3_clk_pa6";
+				nvidia,function = "sdmmc3";	
+				nvidia,pull = <TEGRA_PIN_PULL_NONE>;
+				nvidia,tristate = <TEGRA_PIN_DISABLE>;
+				nvidia,enable-input = <TEGRA_PIN_ENABLE>;
+			};
+			sdmmc3_cmd_pa7 {
+				nvidia,pins = "sdmmc3_cmd_pa7",
+						"sdmmc3_dat0_pb7",
+						"sdmmc3_dat1_pb6",
+						"sdmmc3_dat2_pb5",
+						"sdmmc3_dat3_pb4",
+						"sdmmc3_dat4_pd1",	/* Power rails GPIO */
+						"sdmmc3_dat5_pd0",	/* Power rails GPIO */
+						"sdmmc3_dat6_pd3",	/* RESET */
+						"sdmmc3_dat7_pd4";	/* Power down */
+				nvidia,function = "sdmmc3";	
+				nvidia,pull = <TEGRA_PIN_PULL_UP>;
+				nvidia,tristate = <TEGRA_PIN_DISABLE>;
+				nvidia,enable-input = <TEGRA_PIN_ENABLE>;
+			};
+
+			/* SDMMC4 pinmux */
+			sdmmc4_clk_pcc4 {
+				nvidia,pins = "sdmmc4_clk_pcc4";
+				nvidia,function = "sdmmc4";	
+				nvidia,pull = <TEGRA_PIN_PULL_NONE>;
+				nvidia,tristate = <TEGRA_PIN_DISABLE>;
+				nvidia,enable-input = <TEGRA_PIN_ENABLE>;
+			};
+			sdmmc4_cmd_pt7 {
+				nvidia,pins = "sdmmc4_cmd_pt7",
+						"sdmmc4_dat0_paa0",
+						"sdmmc4_dat1_paa1",
+						"sdmmc4_dat2_paa2",
+						"sdmmc4_dat3_paa3",
+						"sdmmc4_dat4_paa4",
+						"sdmmc4_dat5_paa5",
+						"sdmmc4_dat6_paa6",
+						"sdmmc4_dat7_paa7";
+				nvidia,function = "sdmmc4";
+				nvidia,pull = <TEGRA_PIN_PULL_UP>;
+				nvidia,tristate = <TEGRA_PIN_DISABLE>;
+				nvidia,enable-input = <TEGRA_PIN_ENABLE>;
+			};
+
+			/* I2C1 pinmux */
+			gen1_i2c_scl_pc4 {
+				nvidia,pins = "gen1_i2c_scl_pc4",
+						"gen1_i2c_sda_pc5";
+				nvidia,function = "i2c1";
+				nvidia,pull = <TEGRA_PIN_PULL_NONE>;
+				nvidia,tristate = <TEGRA_PIN_DISABLE>;
+				nvidia,enable-input = <TEGRA_PIN_ENABLE>;
+				nvidia,open-drain = <TEGRA_PIN_ENABLE>;
+			};
+
+			/* I2C2 pinmux */
+			gen2_i2c_scl_pt5 {
+				nvidia,pins = "gen2_i2c_scl_pt5",
+						"gen2_i2c_sda_pt6";
+				nvidia,function = "i2c2";
+				nvidia,pull = <TEGRA_PIN_PULL_NONE>;
+				nvidia,tristate = <TEGRA_PIN_DISABLE>;
+				nvidia,enable-input = <TEGRA_PIN_ENABLE>;
+				nvidia,open-drain = <TEGRA_PIN_ENABLE>;
+			};
+
+			/* I2C3 pinmux */
+			cam_i2c_scl_pbb1 {
+				nvidia,pins = "cam_i2c_scl_pbb1",
+						"cam_i2c_sda_pbb2";
+				nvidia,function = "i2c3";
+				nvidia,pull = <TEGRA_PIN_PULL_NONE>;
+				nvidia,tristate = <TEGRA_PIN_DISABLE>;
+				nvidia,enable-input = <TEGRA_PIN_ENABLE>;
+				nvidia,open-drain = <TEGRA_PIN_ENABLE>;
+			};
+
+			/* I2C4 pinmux */
+			ddc_scl_pv4 {
+				nvidia,pins = "ddc_scl_pv4",
+						"ddc_sda_pv5";
+				nvidia,function = "i2c4";
+				nvidia,pull = <TEGRA_PIN_PULL_NONE>;
+				nvidia,tristate = <TEGRA_PIN_DISABLE>;
+				nvidia,enable-input = <TEGRA_PIN_ENABLE>;
+				nvidia,open-drain = <TEGRA_PIN_ENABLE>;
+			};
+
+			/* Power I2C pinmux */
+			pwr_i2c_scl_pz6 {
+				nvidia,pins = "pwr_i2c_scl_pz6",
+						"pwr_i2c_sda_pz7";
+				nvidia,function = "i2cpwr";
+				nvidia,pull = <TEGRA_PIN_PULL_NONE>;
+				nvidia,tristate = <TEGRA_PIN_DISABLE>;
+				nvidia,enable-input = <TEGRA_PIN_ENABLE>;
+				nvidia,open-drain = <TEGRA_PIN_ENABLE>;
+			};	
+
+			/* HDMI-CEC  pinmux */
+			hdmi_cec_pee3 {
+				nvidia,pins = "hdmi_cec_pee3";
+				nvidia,function = "cec";
+				nvidia,pull = <TEGRA_PIN_PULL_NONE>;
+				nvidia,tristate = <TEGRA_PIN_DISABLE>;
+				nvidia,enable-input = <TEGRA_PIN_ENABLE>;
+				nvidia,open-drain = <TEGRA_PIN_DISABLE>;
+			};
+
+			/* UART-A */
+			ulpi_data0_po1 {
+				nvidia,pins = "ulpi_data0_po1";
+				nvidia,function = "uarta";
+				nvidia,pull = <TEGRA_PIN_PULL_NONE>;
+				nvidia,tristate = <TEGRA_PIN_DISABLE>;
+				nvidia,enable-input = <TEGRA_PIN_DISABLE>;
+			};
+			ulpi_data1_po2 {
+				nvidia,pins = "ulpi_data1_po2";
+				nvidia,function = "uarta";
+				nvidia,pull = <TEGRA_PIN_PULL_DOWN>;
+				nvidia,tristate = <TEGRA_PIN_ENABLE>;
+				nvidia,enable-input = <TEGRA_PIN_ENABLE>;
+			};
+			ulpi_data5_po6 {
+				nvidia,pins = "ulpi_data5_po6";
+				nvidia,function = "uarta";
+				nvidia,pull = <TEGRA_PIN_PULL_NONE>;
+				nvidia,tristate = <TEGRA_PIN_ENABLE>;
+				nvidia,enable-input = <TEGRA_PIN_ENABLE>;
+			};	
+			ulpi_data2_po3 {
+				nvidia,pins = "ulpi_data2_po3",
+						"ulpi_data3_po4",
+						"ulpi_data4_po5",
+						"ulpi_data6_po7",
+						"ulpi_data7_po0";
+				nvidia,function = "uarta";
+				nvidia,pull = <TEGRA_PIN_PULL_NONE>;
+				nvidia,tristate = <TEGRA_PIN_DISABLE>;
+				nvidia,enable-input = <TEGRA_PIN_ENABLE>;
+			};
+
+			/* UART-B */
+			uart2_rts_n_pj6 {
+				nvidia,pins = "uart2_rts_n_pj6";
+				nvidia,function = "uartb";
+				nvidia,pull = <TEGRA_PIN_PULL_NONE>;
+				nvidia,tristate = <TEGRA_PIN_DISABLE>;
+				nvidia,enable-input = <TEGRA_PIN_DISABLE>;
+			};
+			uart2_cts_n_pj5 {
+				nvidia,pins = "uart2_cts_n_pj5";
+				nvidia,function = "uartb";
+				nvidia,pull = <TEGRA_PIN_PULL_NONE>;
+				nvidia,tristate = <TEGRA_PIN_DISABLE>;
+				nvidia,enable-input = <TEGRA_PIN_ENABLE>;
+			};
+
+			/* UART-C */
+			uart3_cts_n_pa1 {
+				nvidia,pins = "uart3_cts_n_pa1",
+						"uart3_rxd_pw7";
+				nvidia,function = "uartc";
+				nvidia,pull = <TEGRA_PIN_PULL_NONE>;
+				nvidia,tristate = <TEGRA_PIN_DISABLE>;
+				nvidia,enable-input = <TEGRA_PIN_ENABLE>;
+			};
+			uart3_rts_n_pc0 {
+				nvidia,pins = "uart3_rts_n_pc0",
+						"uart3_txd_pw6";
+				nvidia,function = "uartc";
+				nvidia,pull = <TEGRA_PIN_PULL_NONE>;
+				nvidia,tristate = <TEGRA_PIN_DISABLE>;
+				nvidia,enable-input = <TEGRA_PIN_DISABLE>;
+			};
+
+			/* UART-D */
+			ulpi_nxt_py2 {
+				nvidia,pins = "ulpi_nxt_py2";
+				nvidia,function = "uartd";
+				nvidia,pull = <TEGRA_PIN_PULL_NONE>;
+				nvidia,tristate = <TEGRA_PIN_ENABLE>;
+				nvidia,enable-input = <TEGRA_PIN_ENABLE>;
+			};
+			ulpi_stp_py3 {
+				nvidia,pins = "ulpi_stp_py3",
+						"ulpi_clk_py0",		/* UART4_TXD is reserved for UART debug */
+						"ulpi_dir_py1";		/* UART4_RXD is reserved for UART debug */
+				nvidia,function = "uartd";
+				nvidia,pull = <TEGRA_PIN_PULL_NONE>;
+				nvidia,tristate = <TEGRA_PIN_ENABLE>;
+				nvidia,enable-input = <TEGRA_PIN_DISABLE>;
+			};
+
+			/* I2S0 pinmux */
+			dap1_fs_pn0 {
+				nvidia,pins = "dap1_fs_pn0",
+						"dap1_din_pn1",
+						"dap1_dout_pn2",
+						"dap1_sclk_pn3";
+				nvidia,function = "i2s0";
+				nvidia,pull = <TEGRA_PIN_PULL_NONE>;
+				nvidia,tristate = <TEGRA_PIN_ENABLE>;
+				nvidia,enable-input = <TEGRA_PIN_ENABLE>;
+			};
+
+			/* I2S1 pinmux */
+			dap2_fs_pa2 {
+				nvidia,pins = "dap2_fs_pa2",
+						"dap2_sclk_pa3",
+						"dap2_din_pa4",
+						"dap2_dout_pa5";
+				nvidia,function = "i2s1";
+				nvidia,pull = <TEGRA_PIN_PULL_NONE>;
+				nvidia,tristate = <TEGRA_PIN_DISABLE>;
+				nvidia,enable-input = <TEGRA_PIN_ENABLE>;
+			};
+
+			/* I2S2 pinmux */
+			dap3_fs_pp0 {
+				nvidia,pins = "dap3_fs_pp0",
+						"dap3_din_pp1";
+				nvidia,function = "i2s2";
+				nvidia,pull = <TEGRA_PIN_PULL_NONE>;
+				nvidia,tristate = <TEGRA_PIN_ENABLE>;
+				nvidia,enable-input = <TEGRA_PIN_ENABLE>;
+			};
+			dap2_dout_pp2 {
+				nvidia,pins = "dap3_dout_pp2",
+						"dap3_sclk_pp3";
+				nvidia,function = "i2s2";
+				nvidia,pull = <TEGRA_PIN_PULL_NONE>;
+				nvidia,tristate = <TEGRA_PIN_DISABLE>;
+				nvidia,enable-input = <TEGRA_PIN_ENABLE>;
+			};
+
+			/* I2S3 pinmux */
+			dap4_fs_pp4 {
+				nvidia,pins = "dap4_fs_pp4",
+						"dap4_din_pp5",
+						"dap4_dout_pp6",
+						"dap4_sclk_pp7";
+				nvidia,function = "i2s3";
+				nvidia,pull = <TEGRA_PIN_PULL_NONE>;
+				nvidia,tristate = <TEGRA_PIN_DISABLE>;
+				nvidia,enable-input = <TEGRA_PIN_ENABLE>;
+			};
+
+			/* I2S4 pinmux */
+			pbb2 {
+				nvidia,pins = "pcc2";
+				nvidia,function = "i2s4";
+				nvidia,pull = <TEGRA_PIN_PULL_NONE>;
+				nvidia,tristate = <TEGRA_PIN_DISABLE>;
+				nvidia,enable-input = <TEGRA_PIN_ENABLE>;
+			};
+
+			/* PCI-e pinmux */
+			pex_l0_rst_n_pdd1 {
+				nvidia,pins = "pex_l0_rst_n_pdd1",
+						"pex_l1_rst_n_pdd5",
+						"pex_l2_rst_n_pcc6";
+				nvidia,function = "pcie";
+				nvidia,pull = <TEGRA_PIN_PULL_NONE>;
+				nvidia,tristate = <TEGRA_PIN_DISABLE>;
+				nvidia,enable-input = <TEGRA_PIN_DISABLE>;
+			};
+			pex_l0_prsnt_n_pdd0 {
+				nvidia,pins = "pex_l0_prsnt_n_pdd0",
+						"pex_l0_clkreq_n_pdd2", 
+						"pex_l1_prsnt_n_pdd4",  
+						"pex_l1_clkreq_n_pdd6", 
+						"pex_l2_prsnt_n_pdd7",  
+						"pex_l2_clkreq_n_pcc7", 
+						"pex_wake_n_pdd3", 		
+				nvidia,pull = <TEGRA_PIN_PULL_NONE>;
+				nvidia,tristate = <TEGRA_PIN_DISABLE>;
+				nvidia,enable-input = <TEGRA_PIN_ENABLE>;
+			};
+
+			/* SPI pinmux */
+			spi1_mosi_px4 {
+				nvidia,pins = "spi1_mosi_px4",
+						"spi1_sck_px5",
+						"spi1_cs0_n_px6",
+						"spi1_miso_px7";
+				nvidia,function = "spi1";
+				nvidia,pull = <TEGRA_PIN_PULL_NONE>;
+				nvidia,tristate = <TEGRA_PIN_ENABLE>;
+				nvidia,enable-input = <TEGRA_PIN_ENABLE>;
+			};
+			spi2_cs1_n_pw2 {
+				nvidia,pins = "spi2_cs1_n_pw2";		/* hp-detect */
+				nvidia,function = "spi2";
+				nvidia,pull = <TEGRA_PIN_PULL_UP>;
+				nvidia,tristate = <TEGRA_PIN_DISABLE>;
+				nvidia,enable-input = <TEGRA_PIN_ENABLE>;
+			};
+			gmi_a16_pj7 {
+				nvidia,pins = "gmi_a16_pj7",		//PCB_ID10
+						"gmi_a17_pb0";		//PCB_ID11
+				nvidia,function = "spi4";
+				nvidia,pull = <TEGRA_PIN_PULL_NONE>;
+				nvidia,tristate = <TEGRA_PIN_ENABLE>;
+				nvidia,enable-input = <TEGRA_PIN_ENABLE>;
+			};
+			gmi_a18_pb1 {
+				nvidia,pins = "gmi_a18_pb1",
+						"gmi_a19_pk7";
+				nvidia,function = "spi4";
+				nvidia,pull = <TEGRA_PIN_PULL_NONE>;
+				nvidia,tristate = <TEGRA_PIN_DISABLE>;
+				nvidia,enable-input = <TEGRA_PIN_ENABLE>;
+			};
+
+			/* Display A pinmux */
+			lcd_d0_pe0 {
+				nvidia,pins = "lcd_d0_pe0",
+						"lcd_d1_pe1",
+						"lcd_d2_pe2",
+						"lcd_d3_pe3",
+						"lcd_d4_pe4",
+						"lcd_d5_pe5",
+						"lcd_d6_pe6",
+						"lcd_d7_pe7",
+						"lcd_d8_pf0",
+						"lcd_d9_pf1",
+						"lcd_d10_pf2",
+						"lcd_d11_pf3",
+						"lcd_d12_pf4",
+						"lcd_d13_pf5",
+						"lcd_d14_pf6",
+						"lcd_d15_pf7",
+						"lcd_d16_pm0",
+						"lcd_d17_pm1",
+						"lcd_d18_pm2",
+						"lcd_d19_pm3",
+						"lcd_d20_pm4",
+						"lcd_d21_pm5",
+						"lcd_d22_pm6",
+						"lcd_d23_pm7",
+						"lcd_pwr0_pb2",
+						"lcd_pwr1_pc1",
+						"lcd_sdin_pz2",
+						"lcd_dc0_pn6",
+						"lcd_pclk_pb3",
+						"lcd_de_pj1",
+						"lcd_hsync_pj3",
+						"lcd_vsync_pj4";
+				nvidia,function = "displaya";
+				nvidia,pull = <TEGRA_PIN_PULL_NONE>;
+				nvidia,tristate = <TEGRA_PIN_DISABLE>;
+				nvidia,enable-input = <TEGRA_PIN_ENABLE>;
+			};
+			lcd_wr_n_pz3 {
+				nvidia,pins = "lcd_wr_n_pz3",
+						"lcd_sdout_pn5",
+						"lcd_cs0_n_pn4";	/* bat detection */
+				nvidia,function = "displaya";
+				nvidia,pull = <TEGRA_PIN_PULL_NONE>;
+				nvidia,tristate = <TEGRA_PIN_ENABLE>;
+				nvidia,enable-input = <TEGRA_PIN_ENABLE>;
+			};
+			clk_32k_out_pa0 {
+				nvidia,pins = "clk_32k_out_pa0";
+				nvidia,function = "blink";
+				nvidia,pull = <TEGRA_PIN_PULL_NONE>;
+				nvidia,tristate = <TEGRA_PIN_DISABLE>;
+				nvidia,enable-input = <TEGRA_PIN_DISABLE>;
+			};	
+
+			/* KBC keys */
+			kb_col0_pq0 {
+				nvidia,pins = "kb_col0_pq0",
+						"kb_col1_pq1",		/* pad req */
+						"kb_row1_pr1",		/* USB charging control */
+						"kb_row3_pr3",		/* unknown */
+						"kb_row8_ps0",		/* power rails GPIO */
+						"kb_row10_ps2",		/* pad irq */
+						"kb_row14_ps6",		/* hall sensor */
+						"kb_row15_ps7";		/* dock irq */
+				nvidia,function = "kbc";
+				nvidia,pull = <TEGRA_PIN_PULL_UP>;
+				nvidia,tristate = <TEGRA_PIN_DISABLE>;
+				nvidia,enable-input = <TEGRA_PIN_ENABLE>;
+			};
+			kb_col4_pq4 {
+				nvidia,pins = "kb_col4_pq4",
+						"kb_col5_pq5",
+						"kb_col7_pq7",
+						"kb_row2_pr2",
+						"kb_row4_pr4",
+						"kb_row5_pr5",
+						"kb_row12_ps4",		/* low bat detection */
+						"kb_row13_ps5";
+				nvidia,function = "kbc";
+				nvidia,pull = <TEGRA_PIN_PULL_NONE>;
+				nvidia,tristate = <TEGRA_PIN_ENABLE>;
+				nvidia,enable-input = <TEGRA_PIN_ENABLE>;
+			};
+			kb_row0_pr0 {
+				nvidia,pins = "kb_row0_pr0";
+				nvidia,function = "rsvd";
+				nvidia,pull = <TEGRA_PIN_PULL_UP>;
+				nvidia,tristate = <TEGRA_PIN_DISABLE>;
+				nvidia,enable-input = <TEGRA_PIN_DISABLE>;
+			};
+			pv0 {
+				nvidia,pins = "pv0",			/* power */
+						"kb_col2_pq2",		/* vol up */
+						"kb_col3_pq3";		/* vol down */
+				nvidia,function = "rsvd";
+				nvidia,pull = <TEGRA_PIN_PULL_UP>;
+				nvidia,tristate = <TEGRA_PIN_ENABLE>;
+				nvidia,enable-input = <TEGRA_PIN_ENABLE>;
+			};
+
+			sdmmc4_rst_n_pcc3 {
+				nvidia,pins = "sdmmc4_rst_n_pcc3", "pu6";
+				nvidia,function = "rsvd1";
+				nvidia,pull = <TEGRA_PIN_PULL_DOWN>;
+				nvidia,tristate = <TEGRA_PIN_DISABLE>;
+				nvidia,enable-input = <TEGRA_PIN_ENABLE>;
+			};
+			gmi_cs0_n_pj0 {
+				nvidia,pins = "gmi_cs0_n_pj0",
+						"gmi_cs1_n_pj2",
+						"gmi_cs2_n_pk3",
+						"gmi_cs3_n_pk4",
+						"gmi_wait_pi7",
+						"gmi_wp_n_pc7";
+				nvidia,function = "rsvd1";
+				nvidia,pull = <TEGRA_PIN_PULL_NONE>;
+				nvidia,tristate = <TEGRA_PIN_ENABLE>;
+				nvidia,enable-input = <TEGRA_PIN_ENABLE>;
+			};
+			gmi_iordy_pi5 {
+				nvidia,pins = "gmi_iordy_pi5",		/* usd-card detect */
+						"vi_d11_pt3",		/* sd-wp-gpio */
+						"pu4";			/* dock in detect */
+				nvidia,function = "rsvd1";
+				nvidia,pull = <TEGRA_PIN_PULL_UP>;
+				nvidia,tristate = <TEGRA_PIN_DISABLE>;
+				nvidia,enable-input = <TEGRA_PIN_ENABLE>;
+			};
+			vi_pclk_pt0 {
+				nvidia,pins = "vi_pclk_pt0";		/* reg */
+				nvidia,function = "rsvd1";
+				nvidia,pull = <TEGRA_PIN_PULL_UP>;
+				nvidia,tristate = <TEGRA_PIN_ENABLE>;
+				nvidia,enable-input = <TEGRA_PIN_ENABLE>;
+			};
+			pv2 {
+				nvidia,pins = "pv2", "pu1",
+						"pu3";			/* docking thermal pwr control */
+				nvidia,function = "rsvd1";
+				nvidia,pull = <TEGRA_PIN_PULL_NONE>;
+				nvidia,tristate = <TEGRA_PIN_DISABLE>;
+				nvidia,enable-input = <TEGRA_PIN_DISABLE>;
+			};
+			vi_d0_pt4 {
+				nvidia,pins = "vi_d0_pt4",
+						"vi_d10_pt2",
+						"vi_hsync_pd7",
+						"vi_vsync_pd6",
+						"pbb0", "pu0", "pu2";
+				nvidia,function = "rsvd1";
+				nvidia,pull = <TEGRA_PIN_PULL_NONE>;
+				nvidia,tristate = <TEGRA_PIN_DISABLE>;
+				nvidia,enable-input = <TEGRA_PIN_ENABLE>;
+			};
+			pv3 {
+				nvidia,pins = "pv3";
+				nvidia,function = "rsvd1";
+				nvidia,pull = <TEGRA_PIN_PULL_NONE>;
+				nvidia,tristate = <TEGRA_PIN_ENABLE>;
+				nvidia,enable-input = <TEGRA_PIN_DISABLE>;
+			};
+			pcc1 {
+				nvidia,pins = "pcc1";
+				nvidia,function = "rsvd1";
+				nvidia,pull = <TEGRA_PIN_PULL_NONE>;
+				nvidia,tristate = <TEGRA_PIN_ENABLE>;
+				nvidia,enable-input = <TEGRA_PIN_ENABLE>;
+			};			
+
+			crt_hsync_pv6 {
+				nvidia,pins = "crt_hsync_pv6",
+						"crt_vsync_pv7";
+				nvidia,function = "crt";
+				nvidia,pull = <TEGRA_PIN_PULL_NONE>;
+				nvidia,tristate = <TEGRA_PIN_ENABLE>;
+				nvidia,enable-input = <TEGRA_PIN_DISABLE>;
+			};
+			gmi_ad8_ph0 {
+				nvidia,pins = "gmi_ad8_ph0";		/* LCD1_BL_PWM */
+				nvidia,function = "pwm0";
+				nvidia,pull = <TEGRA_PIN_PULL_NONE>;
+				nvidia,tristate = <TEGRA_PIN_DISABLE>;
+				nvidia,enable-input = <TEGRA_PIN_DISABLE>;
+			};
+			pu5 {
+				nvidia,pins = "pu5";
+				nvidia,function = "pwm2";
+				nvidia,pull = <TEGRA_PIN_PULL_NONE>;
+				nvidia,tristate = <TEGRA_PIN_ENABLE>;
+				nvidia,enable-input = <TEGRA_PIN_ENABLE>;
+			};
+			cam_mclk_pcc0 {
+				nvidia,pins = "cam_mclk_pcc0";
+				nvidia,function = "vi_alt2";
+				nvidia,pull = <TEGRA_PIN_PULL_UP>;
+				nvidia,tristate = <TEGRA_PIN_DISABLE>;
+				nvidia,enable-input = <TEGRA_PIN_ENABLE>;
+			};
+			jtag_rtck_pu7 {
+				nvidia,pins = "jtag_rtck_pu7";
+				nvidia,function = "rtck";
+				nvidia,pull = <TEGRA_PIN_PULL_NONE>;
+				nvidia,tristate = <TEGRA_PIN_DISABLE>;
+				nvidia,enable-input = <TEGRA_PIN_DISABLE>;
+			};
+
+			vi_d4_pl2 {
+				nvidia,pins = "vi_d4_pl2",
+						"vi_d6_pl4";
+				nvidia,function = "vi";
+				nvidia,pull = <TEGRA_PIN_PULL_NONE>;
+				nvidia,tristate = <TEGRA_PIN_DISABLE>;
+				nvidia,enable-input = <TEGRA_PIN_DISABLE>;
+			};
+			vi_mclk_pt1 {
+				nvidia,pins = "vi_mclk_pt1";
+				nvidia,function = "vi";
+				nvidia,pull = <TEGRA_PIN_PULL_UP>;
+				nvidia,tristate = <TEGRA_PIN_DISABLE>;
+				nvidia,enable-input = <TEGRA_PIN_ENABLE>;
+			};
+
+			clk3_req_pee1 {
+				nvidia,pins = "clk3_req_pee1";
+				nvidia,function = "dev3";
+				nvidia,pull = <TEGRA_PIN_PULL_NONE>;
+				nvidia,tristate = <TEGRA_PIN_ENABLE>;
+				nvidia,enable-input = <TEGRA_PIN_ENABLE>;
+			};
+			gmi_cs4_n_pk2 {
+				nvidia,pins = "gmi_cs4_n_pk2",
+						"gmi_cs6_n_pi3";
+				nvidia,function = "gmi";
+				nvidia,pull = <TEGRA_PIN_PULL_NONE>;
+				nvidia,tristate = <TEGRA_PIN_ENABLE>;
+				nvidia,enable-input = <TEGRA_PIN_ENABLE>;
+			};
+			spi2_sck_px2 {
+				nvidia,pins = "spi2_sck_px2";		/* Power rails GPIO */
+				nvidia,function = "gmi";
+				nvidia,pull = <TEGRA_PIN_PULL_NONE>;
+				nvidia,tristate = <TEGRA_PIN_DISABLE>;
+				nvidia,enable-input = <TEGRA_PIN_ENABLE>;
+			};
+			owr {
+				nvidia,pins = "owr";
+				nvidia,function = "owr";
+				nvidia,pull = <TEGRA_PIN_PULL_NONE>;
+				nvidia,tristate = <TEGRA_PIN_DISABLE>;
+				nvidia,enable-input = <TEGRA_PIN_ENABLE>;
+			};
+			sys_clk_req_pz5 {
+				nvidia,pins = "sys_clk_req_pz5";
+				nvidia,function = "sysclk";
+				nvidia,pull = <TEGRA_PIN_PULL_NONE>;
+				nvidia,tristate = <TEGRA_PIN_DISABLE>;
+				nvidia,enable-input = <TEGRA_PIN_DISABLE>;
+			};
+			clk1_out_pw4 {
+				nvidia,pins = "clk1_out_pw4";
+				nvidia,function = "extperiph1";
+				nvidia,pull = <TEGRA_PIN_PULL_NONE>;
+				nvidia,tristate = <TEGRA_PIN_DISABLE>;
+				nvidia,enable-input = <TEGRA_PIN_ENABLE>;
+			};
+			clk2_out_pw5 {
+				nvidia,pins = "clk2_out_pw5";
+				nvidia,function = "extperiph2";
+				nvidia,pull = <TEGRA_PIN_PULL_NONE>;
+				nvidia,tristate = <TEGRA_PIN_DISABLE>;
+				nvidia,enable-input = <TEGRA_PIN_ENABLE>;
+			};
+			clk3_out_pee0 {
+				nvidia,pins = "clk3_out_pee0";
+				nvidia,function = "extperiph3";
+				nvidia,pull = <TEGRA_PIN_PULL_NONE>;
+				nvidia,tristate = <TEGRA_PIN_DISABLE>;
+				nvidia,enable-input = <TEGRA_PIN_DISABLE>;
+			};
+			clk2_req_pcc5 {
+				nvidia,pins = "clk1_req_pee2",
+						"clk2_req_pcc5";
+				nvidia,function = "dap";
+				nvidia,pull = <TEGRA_PIN_PULL_NONE>;
+				nvidia,tristate = <TEGRA_PIN_DISABLE>;
+				nvidia,enable-input = <TEGRA_PIN_ENABLE>;
+			};	
+			spdif_out_pk5 {
+				nvidia,pins = "spdif_out_pk5";
+				nvidia,function = "spdif";
+				nvidia,pull = <TEGRA_PIN_PULL_NONE>;
+				nvidia,tristate = <TEGRA_PIN_DISABLE>;
+				nvidia,enable-input = <TEGRA_PIN_DISABLE>;
+			};
+			spdif_in_pk6 {
+				nvidia,pins = "spdif_in_pk6";
+				nvidia,function = "spdif";
+				nvidia,pull = <TEGRA_PIN_PULL_NONE>;
+				nvidia,tristate = <TEGRA_PIN_DISABLE>;
+				nvidia,enable-input = <TEGRA_PIN_ENABLE>;
+			};
+
+			pbb4 {
+				nvidia,pins = "pbb4";			/* Power rails GPIO */
+				nvidia,function = "vgp4";
+				nvidia,pull = <TEGRA_PIN_PULL_NONE>;
+				nvidia,tristate = <TEGRA_PIN_DISABLE>;
+				nvidia,enable-input = <TEGRA_PIN_ENABLE>;
+			};
+			pbb5 {
+				nvidia,pins = "pbb5";
+				nvidia,function = "vgp5";
+				nvidia,pull = <TEGRA_PIN_PULL_NONE>;
+				nvidia,tristate = <TEGRA_PIN_DISABLE>;
+				nvidia,enable-input = <TEGRA_PIN_ENABLE>;
+			};
+			pbb6 {
+				nvidia,pins = "pbb6";
+				nvidia,function = "vgp6";
+				nvidia,pull = <TEGRA_PIN_PULL_NONE>;
+				nvidia,tristate = <TEGRA_PIN_DISABLE>;
+				nvidia,enable-input = <TEGRA_PIN_ENABLE>;
+			};
+
+			/* HDMI hot-plug-detect */
+			hdmi_int_pn7 {
+				nvidia,pins = "hdmi_int_pn7";
+				nvidia,function = "rsvd0";
+				nvidia,pull = <TEGRA_PIN_PULL_NONE>;
+				nvidia,tristate = <TEGRA_PIN_ENABLE>;
+				nvidia,enable-input = <TEGRA_PIN_ENABLE>;
+			};
+
+			/* Touch panel GPIO */
+			gmi_ad12_ph4 {
+				nvidia,pins = "gmi_cs7_n_pi6",
+						"gmi_ad12_ph4";		/* Touch IRQ */
+				nvidia,function = "nand";
+				nvidia,pull = <TEGRA_PIN_PULL_UP>;
+				nvidia,tristate = <TEGRA_PIN_DISABLE>;
+				nvidia,enable-input = <TEGRA_PIN_ENABLE>;
+			};
+			gmi_ad10_ph2 {
+				nvidia,pins = "gmi_ad10_ph2",
+						"gmi_ad11_ph3",
+						"gmi_ad14_ph6",		/* Touch RESET */
+						"gmi_rst_n_pi4";
+				nvidia,function = "nand";
+				nvidia,pull = <TEGRA_PIN_PULL_NONE>;
+				nvidia,tristate = <TEGRA_PIN_DISABLE>;
+				nvidia,enable-input = <TEGRA_PIN_DISABLE>;
+			};
+			gmi_ad13_ph5 {
+				nvidia,pins = "gmi_ad13_ph5";
+				nvidia,function = "nand";
+				nvidia,pull = <TEGRA_PIN_PULL_NONE>;
+				nvidia,tristate = <TEGRA_PIN_DISABLE>;
+				nvidia,enable-input = <TEGRA_PIN_ENABLE>;
+			};
+
+			/* Vibrator control */
+			gmi_ad15_ph7 {
+				nvidia,pins = "gmi_ad15_ph7";
+				nvidia,function = "nand";
+				nvidia,pull = <TEGRA_PIN_PULL_DOWN>;
+				nvidia,tristate = <TEGRA_PIN_DISABLE>;
+				nvidia,enable-input = <TEGRA_PIN_DISABLE>;
+			};
+
+			gmi_adv_n_pk0 {
+				nvidia,pins = "gmi_adv_n_pk0",
+						"gmi_clk_pk1",
+						"gmi_ad0_pg0",
+						"gmi_ad1_pg1",
+						"gmi_ad2_pg2",
+						"gmi_ad3_pg3",
+						"gmi_ad6_pg6",
+						"gmi_ad7_pg7",
+						"gmi_wr_n_pi0",
+						"gmi_oe_n_pi1",
+						"gmi_dqs_pi2";
+				nvidia,function = "nand";
+				nvidia,pull = <TEGRA_PIN_PULL_NONE>;
+				nvidia,tristate = <TEGRA_PIN_ENABLE>;
+				nvidia,enable-input = <TEGRA_PIN_DISABLE>;
+			};
+
+			/* Memory bootstrap */
+			gmi_ad4_pg4 {
+				nvidia,pins = "gmi_ad4_pg4",
+						"gmi_ad5_pg5";
+				nvidia,function = "nand";
+				nvidia,pull = <TEGRA_PIN_PULL_NONE>;
+				nvidia,tristate = <TEGRA_PIN_DISABLE>;
+				nvidia,enable-input = <TEGRA_PIN_ENABLE>;
+			};
+		};
+	};
+
+	uartb: serial@70006040 {
+		compatible = "nvidia,tegra30-hsuart";
+		status = "okay";
+
+		/* Broadcom GPS BCM47511 */
+		gnss {
+			compatible = "gps,nmea";
+			vcc-supply = <&vdd_3v3_sys>;
+		};
+	};
+
+	pwm@7000a000 {
+		status = "okay";
+	};
+
+	i2c@7000c000 {		/*i2c1*/
+		status = "okay";
+		clock-frequency = <100000>;
+
+		/* Fortemedia FM34NE voice processor */
+		dsp@60 {
+			compatible = "fortemedia,fm34";
+			reg = <0x60>;
+			vddc-supply = <&vdd_1v8>;
+			vdda-supply = <&vdd_1v8>;									/* fm34_power_down */
+			reset-gpios = <&gpio TEGRA_GPIO(O, 3) GPIO_ACTIVE_LOW>;		/* fm34_reset, out, hi */
+		};
+	};
+
+	i2c2: i2c@7000c400 {		/*i2c2*/
+		status = "okay";
+		clock-frequency = <400000>;
+
+		/* Nuvoton NPCE795LA0BX embedded controller */
+		asusec@15 {
+			compatible = "asus,pad-ec", "asus,ec";
+			reg = <0x15>;
+			interrupt-parent = <&gpio>;
+			interrupts = <TEGRA_GPIO(S, 2) IRQ_TYPE_LEVEL_LOW>;		/* asuspec_apwake, in, hi */
+			request-gpio = <&gpio TEGRA_GPIO(Q, 1) GPIO_ACTIVE_LOW>;	/* asuspec_request, out, hi */
+			asus,dockram = <&dockram_pec>;
+
+			/* Texas Instruments bq24725 SMBus Charge Controller */
+			pad_battery: battery {
+//				power-supplies = <&dock_battery>;
+				charge-full-design = <2940>;	/* mAh */
+				non-removable;
+			};
+		};
+
+		dockram_pec: dockram@17 {
+			compatible = "asus,dockram";
+			reg = <0x17>;
+		};
+	};
+
+	dock-i2c {
+		compatible = "i2c-hotplug-gpio";
+
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		interrupts-extended = <&gpio TEGRA_GPIO(U, 4) IRQ_TYPE_EDGE_BOTH>;
+		detect-gpios = <&gpio TEGRA_GPIO(U, 4) GPIO_ACTIVE_LOW>;		/* asusdec_dock_in, in, lo [in-dock] */
+
+		i2c-parent = <&i2c2>;
+
+		asusec@19 {
+			compatible = "asus,dock-ec", "asus,ec";
+			reg = <0x19>;
+			interrupt-parent = <&gpio>;
+			interrupts = <TEGRA_GPIO(S, 7) IRQ_TYPE_LEVEL_LOW>;		/* asusdec_input, in, hi */
+			request-gpio = <&gpio TEGRA_GPIO(Q, 6) GPIO_ACTIVE_LOW>;	/* asusdec_request, out, hi */
+			asus,dockram = <&dockram_dec>;
+
+			dock_battery: battery {
+				charge-full-design = <2260>;	/* mAh */
+			};
+		};
+
+		dockram_dec: dockram@1b {
+			compatible = "asus,dockram";
+			reg = <0x1b>;
+		};
+	};
+
+	i2c@7000c500 {		/*i2c3*/
+		status = "okay";
+
+		/* Dynaimage ambient light sensor */
+		light-sensor@1c {
+			compatible = "dynaimage,al3010";
+			reg = <0x1c>;
+
+			interrupt-parent = <&gpio>;
+			interrupts = <TEGRA_GPIO(Z, 2) IRQ_TYPE_LEVEL_HIGH>;
+
+			vdd-supply = <&vdd_3v3_sys>;
+		};
+	};
+
+	hdmi_ddc: i2c@7000c700 {		/*i2c4*/
+		status = "okay";
+		clock-frequency = <93750>;
+
+		nvhdcp@3a {
+			compatible = "nvidia,hdcp";
+			reg = <0x3a>;
+		};
+	};
+
+	i2c@7000d000 {		/*i2c5*/
+		status = "okay";
+		clock-frequency = <400000>;
+
+		nct72: temperature-sensor@4c {
+			compatible = "onnn,nct1008";
+			reg = <0x4c>;
+			vcc-supply = <&vdd_3v3_sys>;
+			#thermal-sensor-cells = <1>;
+		};
+
+		/* Texas Instruments TPS659110 PMIC */
+		pmic: pmic@2d {
+			compatible = "ti,tps65911";
+			reg = <0x2d>;
+
+			interrupts = <GIC_SPI 86 IRQ_TYPE_LEVEL_HIGH>;
+			#interrupt-cells = <2>;
+			interrupt-controller;
+
+			ti,en-gpio-sleep = <0 0 1 0 0 0 0 0 0>;
+			ti,system-power-controller;
+			ti,sleep-keep-ck32k;
+			ti,sleep-enable;
+
+			#gpio-cells = <2>;
+			gpio-controller;
+
+			vcc1-supply = <&vdd_5v0_sys>;
+			vcc2-supply = <&vdd_5v0_sys>;
+			vcc3-supply = <&vdd_1v8>;
+			vcc4-supply = <&vdd_5v0_sys>;
+			vcc5-supply = <&vdd_5v0_sys>;
+			vcc6-supply = <&vdd2_reg>;
+			vcc7-supply = <&vdd_5v0_sys>;
+			vccio-supply = <&vdd_5v0_sys>;
+
+			regulators {
+				vdd1 {
+					regulator-name = "vddio_ddr_1v2";
+					regulator-min-microvolt = <600000>;
+					regulator-max-microvolt = <1500000>;
+					regulator-always-on;
+					regulator-boot-on;
+					ti,regulator-ext-sleep-control = <8>;
+				};
+
+				vdd2_reg: vdd2 {
+					regulator-name = "vdd2_1v2";
+					regulator-min-microvolt = <1200000>;
+					regulator-max-microvolt = <1200000>;
+					regulator-always-on;
+					regulator-boot-on;
+				};
+
+				vdd_cpu: vddctrl {
+					regulator-name = "vdd_cpu,vdd_sys";
+					regulator-min-microvolt = <800000>;
+					regulator-max-microvolt = <1250000>;
+					regulator-coupled-with = <&vdd_core>;
+					regulator-coupled-max-spread = <300000>;
+					regulator-max-step-microvolt = <100000>;
+					regulator-always-on;
+					ti,regulator-ext-sleep-control = <1>;
+
+					nvidia,tegra-cpu-regulator;
+				};
+
+				vdd_1v8: vio {
+					regulator-name = "vdd_1v8_gen";
+					regulator-min-microvolt = <1800000>;
+					regulator-max-microvolt = <1800000>;
+					regulator-always-on;
+					regulator-boot-on;
+				};
+
+				/* eMMC VDD */
+				vcore_emmc: ldo1 {
+					regulator-name = "vdd_pexa,vdd_pexb";
+					regulator-min-microvolt = <1000000>;
+					regulator-max-microvolt = <3300000>;
+					regulator-always-on;
+				};
+
+				/* uSD slot VDD */
+				vdd_usd: ldo2 {
+					regulator-name = "vdd_sata,avdd_plle";
+					regulator-min-microvolt = <1050000>;
+					regulator-max-microvolt = <1050000>;
+				};
+
+				/* uSD slot VDDIO */
+				vddio_usd: ldo3 {
+					regulator-name = "vddio_usd";
+					regulator-min-microvolt = <1000000>;
+					regulator-max-microvolt = <3300000>;
+				};
+
+				ldo4 {
+					regulator-name = "vdd_rtc";
+					regulator-min-microvolt = <1200000>;
+					regulator-max-microvolt = <1200000>;
+					regulator-always-on;
+				};
+
+				ldo5 {
+					regulator-name = "vddio_sdmmc,avdd_vdac";
+					regulator-min-microvolt = <1800000>;
+					regulator-max-microvolt = <1800000>;
+				};
+
+				ldo6 {
+					regulator-name = "avdd_dsi_csi,pwrdet_mipi";
+					regulator-min-microvolt = <1200000>;
+					regulator-max-microvolt = <1200000>;
+				};
+
+				ldo7 {
+					regulator-name = "vdd_pllm,x,u,a_p_c_s";
+					regulator-min-microvolt = <1200000>;
+					regulator-max-microvolt = <1200000>;
+					regulator-always-on;
+					regulator-boot-on;
+					ti,regulator-ext-sleep-control = <8>;
+				};
+
+				ldo8 {
+					regulator-name = "vdd_ddr_hs";
+					regulator-min-microvolt = <1000000>;
+					regulator-max-microvolt = <1000000>;
+					regulator-always-on;
+					ti,regulator-ext-sleep-control = <8>;
+				};
+			};
+		};
+
+		vdd_core: core-regulator@60 {
+			compatible = "ti,tps62361";
+			reg = <0x60>;
+
+			regulator-name = "tps62361-vout";
+			regulator-min-microvolt = <500000>;
+			regulator-max-microvolt = <1350000>;
+			regulator-coupled-with = <&vdd_cpu>;
+			regulator-coupled-max-spread = <300000>;
+			regulator-max-step-microvolt = <100000>;
+			regulator-boot-on;
+			regulator-always-on;
+			ti,enable-vout-discharge;
+			ti,vsel0-state-high;
+			ti,vsel1-state-high;
+
+			nvidia,tegra-core-regulator;
+		};
+	};
+
+	regulators {
+		compatible = "simple-bus";
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		vdd_5v0_sys: regulator@0 {
+			compatible = "regulator-fixed";
+			reg = <0>;
+			regulator-name = "vdd_5v0";
+			regulator-min-microvolt = <5000000>;
+			regulator-max-microvolt = <5000000>;
+			regulator-always-on;
+			regulator-boot-on;
+		};
+
+		vdd_3v3_sys: regulator@1 {
+			compatible = "regulator-fixed";
+			reg = <1>;
+			regulator-name = "vdd_3v3";
+			regulator-min-microvolt = <3300000>;
+			regulator-max-microvolt = <3300000>;
+			regulator-always-on;
+			regulator-boot-on;
+			vin-supply = <&vdd_5v0_sys>;
+		};
+
+		vdd_pnl: regulator@2 {
+			compatible = "regulator-fixed";
+			reg = <2>;
+			regulator-name = "vdd_panel";
+			regulator-min-microvolt = <3300000>;
+			regulator-max-microvolt = <3300000>;
+			regulator-enable-ramp-delay = <300000>;
+			gpio = <&gpio TEGRA_GPIO(W, 1) GPIO_ACTIVE_HIGH>;
+			enable-active-high;
+			vin-supply = <&vdd_3v3_sys>;
+		};
+
+		cam_vddc: regulator@3 {
+			compatible = "regulator-fixed";
+			reg = <3>;
+			regulator-name = "camera_vddc";
+			regulator-min-microvolt = <1200000>;
+			regulator-max-microvolt = <1200000>;
+			gpio = <&gpio TEGRA_GPIO(BB, 7) GPIO_ACTIVE_HIGH>;
+			enable-active-high;
+			vin-supply = <&vdd2_reg>;
+		};
+	};
+
+	pmc@7000e400 {
+		status = "okay";
+		nvidia,invert-interrupt;
+		nvidia,suspend-mode = <1>;
+		nvidia,cpu-pwr-good-time = <2000>;
+		nvidia,cpu-pwr-off-time = <200>;
+		nvidia,core-pwr-good-time = <3845 3845>;
+		nvidia,core-pwr-off-time = <0>;
+		nvidia,core-power-req-active-high;
+		nvidia,sys-clock-req-active-high;
+		nvidia,lp0-vec = <0xbddf9000 0x2000>;	// passed by bootloader
+
+		/* Set DEV_OFF + PWR_OFF_SET bit in DCDC control register of TPS65911 PMIC  */
+		i2c-thermtrip {
+			nvidia,i2c-controller-id = <4>;
+			nvidia,bus-addr = <0x2d>;
+			nvidia,reg-addr = <0x3f>;
+			nvidia,reg-data = <0x81>;
+		};
+	};
+
+	ahub@70080000 {
+		i2s@70080400 {		/* i2s1 */
+			status = "okay";
+		};
+
+		/* BT SCO */
+		i2s@70080600 {		/* i2s3 */
+			status = "okay";
+		};
+	};
+
+	/* uSD slot on left side */
+	sdhci@78000000 {		/* sdmmc1 */
+		status = "okay";
+
+		cd-gpios = <&gpio TEGRA_GPIO(I, 5) GPIO_ACTIVE_LOW>;	// sdhci_cd, in, lo [card in]
+		bus-width = <4>;
+
+		vmmc-supply = <&vddio_usd>;	/* ldo3 */
+		vqmmc-supply = <&vdd_usd>;	/* ldo2 */
+	};
+
+	brcm_wifi_pwrseq: wifi-pwrseq {
+		compatible = "mmc-pwrseq-simple";
+
+		clocks = <&tegra_pmc TEGRA_PMC_CLK_BLINK>;
+		clock-names = "ext_clock";
+
+		reset-gpios = <&gpio TEGRA_GPIO(D, 3) GPIO_ACTIVE_LOW>;	// wlan_rst, out, lo [wifi-off]
+		post-power-on-delay-ms = <300>;
+		power-off-delay-us = <300>;
+	};
+
+	/* internal SDIO WiFi */
+	sdhci@78000400 {		/* sdmmc3 */
+		status = "okay";
+
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		keep-power-in-suspend;
+		bus-width = <4>;
+		non-removable;
+
+		mmc-pwrseq = <&brcm_wifi_pwrseq>;
+		vmmc-supply = <&vdd_3v3_sys>;
+		vqmmc-supply = <&vdd_1v8>;
+
+		/* WIFI setup is in dts */
+	};
+
+	/* internal eMMC */
+	sdhci@78000600 {		/* sdmmc4 */
+		status = "okay";
+		bus-width = <8>;
+		vmmc-supply = <&vcore_emmc>;
+		vqmmc-supply = <&vdd_1v8>;
+		non-removable;
+	};
+
+	/* USB via ASUS connector */
+	usb@7d000000 {			/* usb1 */
+		compatible = "nvidia,tegra30-udc";
+		status = "okay";
+		dr_mode = "peripheral";
+	};
+
+	usb-phy@7d000000 {		/* phy1 */
+		status = "okay";
+		dr_mode = "peripheral";
+		nvidia,hssync-start-delay = <0>;
+		nvidia,xcvr-lsfslew = <2>;
+		nvidia,xcvr-lsrslew = <2>;
+	};
+
+	/* Dock's USB port */
+	usb@7d008000 {			/* usb3 */
+		status = "okay";		
+	}
+
+	usb-phy@7d008000 {		/* phy3 */
+		status = "okay";
+	}
+
+	backlight_lvds: backlight-lvds {
+		compatible = "pwm-backlight";
+
+		enable-gpios = <&gpio TEGRA_GPIO(H, 2) GPIO_ACTIVE_HIGH>;
+		power-supply = <&vdd_5v0_sys>;
+		pwms = <&pwm 0 5000000>;
+
+		brightness-levels = <2 4 8 16 32 64 128 255>;
+		default-brightness-level = <6>;
+	};
+
+	clocks {
+		compatible = "simple-bus";
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		clk32k_in: clock@0 {
+			compatible = "fixed-clock";
+			reg = <0>;
+			#clock-cells = <0>;
+			clock-frequency = <32768>;
+		};
+
+		// TODO: clk_out2 <- clk_m [26 MHz]
+	};
+
+	cpus {
+		cpu0: cpu@0 {
+			cpu-supply = <&vdd_cpu>;
+			operating-points-v2 = <&cpu0_opp_table>;
+			#cooling-cells = <2>;
+		};
+		cpu@1 {
+			cpu-supply = <&vdd_cpu>;
+			operating-points-v2 = <&cpu0_opp_table>;
+		};
+		cpu@2 {
+			cpu-supply = <&vdd_cpu>;
+			operating-points-v2 = <&cpu0_opp_table>;
+		};
+		cpu@3 {
+			cpu-supply = <&vdd_cpu>;
+			operating-points-v2 = <&cpu0_opp_table>;
+		};
+	};
+
+	firmware {
+		trusted-foundations {
+			compatible = "tlm,trusted-foundations";
+			tlm,version-major = <2>;
+			tlm,version-minor = <8>;
+		};
+	};
+
+	gpio-keys {
+		compatible = "gpio-keys";
+		interrupt-parent = <&gpio>;
+
+		power {
+			label = "Power";
+			gpios = <&gpio TEGRA_GPIO(V, 0) GPIO_ACTIVE_LOW>;	/* KEY_POWER, in, hi */
+			linux,code = <KEY_POWER>;
+			debounce-interval = <10>;
+			wakeup-event-action = <EV_ACT_ASSERTED>;
+			wakeup-source;
+		};
+
+		volume-up {
+			label = "Volume Up";
+			gpios = <&gpio TEGRA_GPIO(Q, 2) GPIO_ACTIVE_LOW>;	/* KEY_VOLUMEUP, in, hi */
+			linux,code = <KEY_VOLUMEUP>;
+			debounce-interval = <10>;
+			wakeup-event-action = <EV_ACT_ASSERTED>;
+			wakeup-source;
+		};
+
+		volume-down {
+			label = "Volume Down";
+			gpios = <&gpio TEGRA_GPIO(Q, 3) GPIO_ACTIVE_LOW>;	/* KEY_VOLUMEDOWN, in, hi */
+			linux,code = <KEY_VOLUMEDOWN>;
+			debounce-interval = <10>;
+			wakeup-event-action = <EV_ACT_ASSERTED>;
+			wakeup-source;
+		};
+
+		dock-hall-sensor {
+			label = "Lid";
+			gpios = <&gpio TEGRA_GPIO(S, 6) GPIO_ACTIVE_LOW>;	/* asusdec_hall_sensor, in, hi [open] */
+			linux,input-type = <EV_SW>;
+			linux,code = <SW_LID>;
+			debounce-interval = <10>;
+			wakeup-source;
+		};
+
+		ac-15v {
+			label = "Power adapter 15V";
+			gpios = <&gpio TEGRA_GPIO(H, 5) GPIO_ACTIVE_HIGH>;	/* LIMIT_SET1, in, lo [usb: pc] */
+			linux,input-type = <EV_SW>;
+			linux,code = <SW_DOCK>;
+			debounce-interval = <10>;
+			wakeup-source;
+		};
+
+		lineout-detect {
+			label = "Audio dock line-out detect";
+			gpios = <&gpio TEGRA_GPIO(X, 3) GPIO_ACTIVE_LOW>;	/* lineout_int, in, hi */
+			linux,input-type = <EV_SW>;
+			linux,code = <SW_LINEOUT_INSERT>;
+			debounce-interval = <10>;
+			wakeup-source;
+		};
+	};
+
+	hdmi-cec@70015000 {
+		status = "okay";
+	};
+
+	hda@70030000 {
+		status = "okay";
+	};
+
+	thermal-zones {
+		nct72-local {
+			polling-delay-passive = <1000>; /* milliseconds */
+			polling-delay = <0>; /* milliseconds */
+
+			thermal-sensors = <&nct72 0>;
+		};
+
+		nct72-remote {
+			polling-delay-passive = <1000>; /* milliseconds */
+			polling-delay = <5000>; /* milliseconds */
+
+			thermal-sensors = <&nct72 1>;
+
+			trips {
+				trip0: cpu-alert0 {
+					/* start throttling at 50C */
+					temperature = <50000>;
+					hysteresis = <3000>;
+					type = "passive";
+				};
+
+				trip1: cpu-crit {
+					/* shut down at 60C */
+					temperature = <60000>;
+					hysteresis = <2000>;
+					type = "critical";
+				};
+			};
+
+			cooling-maps {
+				map0 {
+					trip = <&trip0>;
+					cooling-device = <&cpu0 THERMAL_NO_LIMIT THERMAL_NO_LIMIT>;
+				};
+			};
+		};
+	};
+};
+
+/*
+	interrupt-parent = <&gpio>;
+	interrupts = <TEGRA_GPIO(S, 5) IRQ_TYPE_EDGE_BOTH>,	// dock_charging, in, lo
+		     <TEGRA_GPIO(S, 4) IRQ_TYPE_EDGE_BOTH>;	// low_battery_detect, in, lo
+		     <TEGRA_GPIO(N, 4) IRQ_TYPE_EDGE_BOTH>;	// battery_detect, in, lo
+	interrupt-names = "dock-charging", "low", "detect";
+
+	/delete-property/ interrupts;
+	interrupts-extended = <&lic GIC_SPI 53 IRQ_TYPE_LEVEL_HIGH>,
+				<&gpio TEGRA_GPIO(CC, 2) IRQ_TYPE_EDGE_FALLING>;	// temp_alert, in, hi	[LEVEL_LOW]
+	interrupt-names = "irq", "smbus_alert";
+*/


### PR DESCRIPTION
This commit might not be merged yet, but is definitely cleaner then TF300T and TF700T device trees. Those transformer trees should be reworked.

If you decide to merge it anyway,  I will push one more patch after testing builds to fix all bugs I could find connected with tree.

Some parts of tf201 dts can be moved to common, but I wasn't 100% certain about their common nature among TFs and proper description of some stuff in split form.

