### PR TITLE
Samsung i927 fixes

### DIFF
--- a/arch/arm/boot/dts/tegra20-glide.dts
+++ b/arch/arm/boot/dts/tegra20-glide.dts
@@ -869,8 +869,8 @@
 	usb_ta_charger: max8922-charger {
 		compatible = "maxim,max8903";
 		chg-gpios = <&stmpegpio 16 GPIO_ACTIVE_LOW>;
-		cen-gpios = <&gpio TEGRA_GPIO(R, 3) GPIO_ACTIVE_HIGH>;
-		uok-gpios = <&gpio TEGRA_GPIO(T, 0) GPIO_ACTIVE_HIGH>;
+		cen-gpios = <&gpio TEGRA_GPIO(R, 3) GPIO_ACTIVE_LOW>;
+		uok-gpios = <&gpio TEGRA_GPIO(T, 0) GPIO_ACTIVE_LOW>;
 		/*
 		 * Original sources also use FSA9480 for USB charger
 		 * detection, but it's on extcon and not GPIO,

--- a/arch/arm/boot/dts/tegra20-glide.dts
+++ b/arch/arm/boot/dts/tegra20-glide.dts
@@ -1777,6 +1777,7 @@
 		gpio = <&gpio TEGRA_GPIO(X, 5) GPIO_ACTIVE_HIGH>;
 		regulator-enable-ramp-delay = <125000>;
 		regulator-boot-on;
+		regulator-always-on;
 		enable-active-high;
 	};
 
@@ -1798,12 +1799,12 @@
 		nvidia,hp-det-gpios = <&gpio TEGRA_GPIO(L, 3) GPIO_ACTIVE_HIGH>;
 
 		nvidia,audio-routing =
-			"Int Spk", "SPKOUTLP",
-			"Int Spk", "SPKOUTLN",
+			"Speakers", "SPKOUTLP",
+			"Speakers", "SPKOUTLN",
 			"Headphone Jack", "HPOUT1L",
 			"Headphone Jack", "HPOUT1R",
-			"Earpiece Spk", "HPOUT2P",
-			"Earpiece Spk", "HPOUT2N",
+			"Int Spk", "HPOUT2P",
+			"Int Spk", "HPOUT2N",
 			"IN1LP", "Mic Jack",
 			"IN1LN", "Mic Jack";
 		/* TODO: routes for modem and, probably, BT SCO */

--- a/drivers/gpu/drm/grate/rgb.c
+++ b/drivers/gpu/drm/grate/rgb.c
@@ -127,6 +127,10 @@ static void tegra_rgb_encoder_enable(struct drm_encoder *encoder)
 	tegra_dc_writel(rgb->dc, value, DC_COM_PIN_OUTPUT_POLARITY(1));
 
 	/* XXX: parameterize? */
+	if (of_machine_is_compatible("samsung,i927")) {
+		/* Set DISP_COLOR_SWAP bit to swap red and blue colors */
+		tegra_dc_writel(rgb->dc, (1 << 16), DC_DISP_DISP_COLOR_CONTROL);
+	}
 	value = DISP_DATA_FORMAT_DF1P1C | DISP_ALIGNMENT_MSB |
 		DISP_ORDER_RED_BLUE;
 	tegra_dc_writel(rgb->dc, value, DC_DISP_DISP_INTERFACE_CONTROL);

--- a/drivers/gpu/drm/tegra/rgb.c
+++ b/drivers/gpu/drm/tegra/rgb.c
@@ -125,6 +125,10 @@ static void tegra_rgb_encoder_enable(struct drm_encoder *encoder)
 	tegra_dc_writel(rgb->dc, value, DC_COM_PIN_OUTPUT_POLARITY(1));
 
 	/* XXX: parameterize? */
+	if (of_machine_is_compatible("samsung,i927")) {
+		/* Set DISP_COLOR_SWAP bit to swap red and blue colors */
+		tegra_dc_writel(rgb->dc, (1 << 16), DC_DISP_DISP_COLOR_CONTROL);
+	}
 	value = DISP_DATA_FORMAT_DF1P1C | DISP_ALIGNMENT_MSB |
 		DISP_ORDER_RED_BLUE;
 	tegra_dc_writel(rgb->dc, value, DC_DISP_DISP_INTERFACE_CONTROL);

--- a/drivers/mfd/max8907.c
+++ b/drivers/mfd/max8907.c
@@ -229,7 +229,7 @@ static int max8907_i2c_probe(struct i2c_client *i2c,
 	}
 
 	ret = regmap_add_irq_chip(max8907->regmap_gen, max8907->i2c_gen->irq,
-				  IRQF_ONESHOT | IRQF_SHARED | IRQF_NO_AUTOEN,
+				  IRQF_ONESHOT | IRQF_SHARED,
 				  -1, &max8907_chg_irq_chip,
 				  &max8907->irqc_chg);
 	if (ret != 0) {
@@ -252,8 +252,6 @@ static int max8907_i2c_probe(struct i2c_client *i2c,
 		dev_err(&i2c->dev, "failed to add rtc irq chip: %d\n", ret);
 		goto err_irqc_rtc;
 	}
-
-	enable_irq(max8907->i2c_gen->irq);
 
 	ret = mfd_add_devices(max8907->dev, -1, max8907_cells,
 			      ARRAY_SIZE(max8907_cells), NULL, 0, NULL);

--- a/drivers/power/supply/max8903_charger.c
+++ b/drivers/power/supply/max8903_charger.c
@@ -340,7 +340,7 @@ static int max8903_otg_enable(struct regulator_dev *rdev)
 	/* Disable charging */
 	data->otg_en = true;
 	if (data->usb_in)
-		gpiod_set_value(data->cen, 1);
+		gpiod_set_value(data->cen, 0);
 	data->usb_in = false;
 
 	if (data->psy_desc.type != POWER_SUPPLY_TYPE_BATTERY)

--- a/sound/soc/tegra/tegra_wm8994.c
+++ b/sound/soc/tegra/tegra_wm8994.c
@@ -125,7 +125,7 @@ static int tegra_wm8994_remove(struct snd_soc_card *card)
 
 SND_SOC_DAILINK_DEFS(wm8994_hifi,
 	DAILINK_COMP_ARRAY(COMP_EMPTY()),
-	DAILINK_COMP_ARRAY(COMP_CODEC(NULL, "wm8994-hifi")),
+	DAILINK_COMP_ARRAY(COMP_CODEC(NULL, "wm8994-aif1")),
 	DAILINK_COMP_ARRAY(COMP_EMPTY()));
 
 static struct snd_soc_dai_link tegra_wm8994_dai = {

--- a/sound/soc/tegra/tegra_wm8994.c
+++ b/sound/soc/tegra/tegra_wm8994.c
@@ -149,6 +149,7 @@ static struct snd_soc_card snd_soc_tegra_wm8994 = {
 
 static const struct tegra_asoc_data tegra_wm8994_data = {
 	.mclk_rate = tegra_wm8994_mclk_rate,
+	.mclk_id = WM8994_SYSCLK_MCLK1,
 	.dapm_event = tegra_wm8994_event,
 	.card = &snd_soc_tegra_wm8994,
 	.add_common_dapm_widgets = true,


### PR DESCRIPTION
Hello! Noticed that this Linux fork has support for Samsung SGH-i927 phone which I originally did for postmarketOS. However it's a bit broken, but this PR makes it working OK.

One thing that I don't understand is why the original 5.2.1 kernel which I worked with doesn't have the issue with colors inverted, but this has with both grate/tegra DRM drivers.