### PR TITLE
ARM: tegra: transformer: Add interrupt to temperature sensor node

### DIFF
--- a/arch/arm/boot/dts/tegra30-asus-transformer-common.dtsi
+++ b/arch/arm/boot/dts/tegra30-asus-transformer-common.dtsi
@@ -1192,6 +1192,9 @@
 			compatible = "onnn,nct1008";
 			reg = <0x4c>;
 
+			interrupt-parent = <&gpio>;
+			interrupts = <TEGRA_GPIO(CC, 2) IRQ_TYPE_EDGE_FALLING>;
+
 			vcc-supply = <&vdd_3v3_sys>;
 			#thermal-sensor-cells = <1>;
 		};


### PR DESCRIPTION
You may squash it into https://github.com/grate-driver/linux/commit/09d709f4373f370c573fdef86d340b34dc621602#diff-d9a889696b367a484322e3667ee72b5ebd92bae3d9aa9d2595fba7a99c8b3e2a

"lm90 0-004c: temp2 out of range, please check!" 
apperas in dmesg on stress teast on tf201 and tf700t