### PR TITLE
WIP: ARM: tegra: Support for Surface RT Type/Touch/Power-Cover; Display fix

### DIFF
--- a/arch/arm/boot/dts/tegra30-microsoft-surface-rt.dts
+++ b/arch/arm/boot/dts/tegra30-microsoft-surface-rt.dts
@@ -36,6 +36,8 @@
 		dc@54200000 {
 			rgb {
 				status = "okay";
+				
+				nvidia,panel = <&panel>;
 
 				port@0 {
 					lcd_output: endpoint {

--- a/arch/arm/boot/dts/tegra30-microsoft-surface-rt.dts
+++ b/arch/arm/boot/dts/tegra30-microsoft-surface-rt.dts
@@ -89,6 +89,31 @@
 	pwm@7000a000 {
 		status = "okay";
 	};
+	
+	i2c1: i2c@7000c000 {
+		status = "okay";
+		clock-frequency = <400000>;
+	};
+	
+	cover-i2c {
+		compatible = "i2c-hotplug-gpio";
+		
+		#address-cells = <1>;
+		#size-cells = <0>;
+		
+		interrupts-extended = <&gpio TEGRA_GPIO(S,0) IRQ_TYPE_EDGE_BOTH>;
+		detect-gpios = <&gpio TEGRA_GPIO(S,0) GPIO_ACTIVE_HIGH>;
+		
+		i2c-parent = <&i2c1>;
+		
+		cover@0 {
+			compatible = "hid-over-i2c";
+			reg = <0x00>;
+			hid-descr-addr = <0x0041>;
+			interrupt-parent = <&gpio>;
+			interrupts = <TEGRA_GPIO(O, 5) IRQ_TYPE_LEVEL_LOW>;
+		};
+	};
 
 	i2c@7000c400 {
 		status = "okay";

--- a/drivers/i2c/i2c-core-base.c
+++ b/drivers/i2c/i2c-core-base.c
@@ -824,6 +824,12 @@ static unsigned short i2c_encode_flags_to_addr(struct i2c_client *client)
  * are purposely not enforced, except for the general call address. */
 static int i2c_check_addr_validity(unsigned int addr, unsigned short flags)
 {
+	// Fix for Surface RT tCover support.
+	// tCover uses address 0x00 which is reserved for general call
+	if (addr == 0x00 && of_machine_is_compatible("microsoft,surface-rt")) {
+		return 0;
+	}
+
 	if (flags & I2C_CLIENT_TEN) {
 		/* 10-bit address, all values are valid */
 		if (addr > 0x3ff)
@@ -852,6 +858,12 @@ int i2c_check_7bit_addr_validity_strict(unsigned short addr)
 	 *  0x78-0x7b  10-bit slave addressing
 	 *  0x7c-0x7f  Reserved for future purposes
 	 */
+	// Fix for Surface RT tCover support.
+	// tCover uses address 0x00 which is reserved for general call
+	if (addr == 0x00 && of_machine_is_compatible("microsoft,surface-rt")) {
+		return 0;
+	}
+
 	if (addr < 0x08 || addr > 0x77)
 		return -EINVAL;
 	return 0;


### PR DESCRIPTION
# Type/Touch/Power-Cover Support for Surface RT:
tCover is connected via HID over I2C.
Sadly the slave address is 0x00 which is reserved as general call address.
The patch allows the I2C driver only to accept 0x00 as valid address if the device is a Surface RT.
`i2c-hotplug-gpio` allows to hotplug the tCovers.
## Tests
Tested on Surface RT with latest grate-linux kernel.
Plugged in the first cover after boot and changed the covers randomly.

Tested with following covers:
- TypeCover 1.Gen
- TypeCover 2.Gen
- TouchCover 1.Gen
- TouchCover 2.Gen

VendorID and ProductID were read correctly and every cover worked after hotplug.

# Display fix:
Added the property: `nvidia,panel`