### PR TITLE
WIP: ARM: dts: tegra30-microsoft-surfacert: fix gpio-keys

### DIFF
--- a/arch/arm/boot/dts/tegra30-microsoft-surface-rt.dts
+++ b/arch/arm/boot/dts/tegra30-microsoft-surface-rt.dts
@@ -241,7 +241,7 @@
 
 		power {
 			label = "Power Button";
-			gpios = <&gpio TEGRA_GPIO(V, 0) GPIO_ACTIVE_LOW>;
+			gpios = <&gpio TEGRA_GPIO(V, 0) GPIO_ACTIVE_HIGH>;
 			linux,code = <KEY_POWER>;
 			debounce-interval = <10>;
 			wakeup-source;
@@ -249,7 +249,7 @@
 
 		windows-button {
 			label = "Windows Button";
-			gpios = <&gpio TEGRA_GPIO(S, 5) GPIO_ACTIVE_LOW>;
+			gpios = <&gpio TEGRA_GPIO(S, 5) GPIO_ACTIVE_HIGH>;
 			linux,code = <KEY_LEFTMETA>;
 			debounce-interval = <10>;
 		};


### PR DESCRIPTION
Sorry for sending so small update, we missed this while testing first PR.
`KEY_LEFTMETA` and `KEY_POWER` had default state 1 in evtest.