### PR TITLE
WIP: ARM: dts: tegra30-microsoft-surfacert: add label for gpio-keys

### DIFF
--- a/arch/arm/boot/dts/tegra30-microsoft-surface-rt.dts
+++ b/arch/arm/boot/dts/tegra30-microsoft-surface-rt.dts
@@ -239,6 +239,8 @@
 	gpio-keys {
 		compatible = "gpio-keys";
 
+		label = "GPIO Buttons";
+
 		power {
 			label = "Power Button";
 			gpios = <&gpio TEGRA_GPIO(V, 0) GPIO_ACTIVE_HIGH>;


### PR DESCRIPTION
I couldn't set up dtschema on my host, so i can't check it. Feel free to close PR if it doesn't pass lint check or something like that. As i said in IRC it is not very important. ~~Actually the DT has more important things to do and i'm doing useless stuff.~~ I also don't know where it is documented. I used for reference upstream device-trees.

Before patch:
```
microsoft-surfacert:~$ evtest
No device specified, trying to scan all of /dev/input/event*
Not running as root, no devices may be available.
Available devices:
/dev/input/event0:	gpio-keys
...
```

After patch:
```
microsoft-surfacert:~$ evtest
No device specified, trying to scan all of /dev/input/event*
Not running as root, no devices may be available.
Available devices:
/dev/input/event0:	GPIO Buttons
...
```