### PR TITLE
WIP: ARM: tegra: Surface RT devicetree update

### DIFF
--- a/arch/arm/boot/dts/tegra30-microsoft-surface-rt-efi.dts
+++ b/arch/arm/boot/dts/tegra30-microsoft-surface-rt-efi.dts
@@ -17,6 +17,26 @@
 		regulator-max-microvolt = <3300000>;
 		regulator-always-on;
 	};
+	
+	cover-i2c {
+		compatible = "i2c-hotplug-gpio";
+
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		interrupts-extended = <&gpio TEGRA_GPIO(S,0) IRQ_TYPE_EDGE_BOTH>;
+		detect-gpios = <&gpio TEGRA_GPIO(S,0) GPIO_ACTIVE_HIGH>;
+
+		i2c-parent = <&i2c1>;
+
+		cover@0 {
+			compatible = "hid-over-i2c";
+			reg = <0x00>;
+			hid-descr-addr = <0x0041>;
+			interrupt-parent = <&gpio>;
+			interrupts = <TEGRA_GPIO(O, 5) IRQ_TYPE_LEVEL_LOW>;
+		};
+	};
 };
 
 &pmic {

--- a/arch/arm/boot/dts/tegra30-microsoft-surface-rt.dts
+++ b/arch/arm/boot/dts/tegra30-microsoft-surface-rt.dts
@@ -93,26 +93,6 @@
 		clock-frequency = <400000>;
 	};
 
-	cover-i2c {
-		compatible = "i2c-hotplug-gpio";
-
-		#address-cells = <1>;
-		#size-cells = <0>;
-
-		interrupts-extended = <&gpio TEGRA_GPIO(S,0) IRQ_TYPE_EDGE_BOTH>;
-		detect-gpios = <&gpio TEGRA_GPIO(S,0) GPIO_ACTIVE_HIGH>;
-
-		i2c-parent = <&i2c1>;
-
-		cover@0 {
-			compatible = "hid-over-i2c";
-			reg = <0x00>;
-			hid-descr-addr = <0x0041>;
-			interrupt-parent = <&gpio>;
-			interrupts = <TEGRA_GPIO(O, 5) IRQ_TYPE_LEVEL_LOW>;
-		};
-	};
-
 	i2c@7000c400 {
 		status = "okay";
 		clock-frequency = <400000>;

--- a/arch/arm/boot/dts/tegra30-microsoft-surface-rt.dts
+++ b/arch/arm/boot/dts/tegra30-microsoft-surface-rt.dts
@@ -283,6 +283,21 @@
 			debounce-interval = <10>;
 		};
 	};
+	
+	gpio-hall-sensor {
+		compatible = "gpio-keys";
+
+		label = "GPIO Hall Effect Sensor";
+
+		hall-sensor {
+			label = "Hall Effect Sensor";
+			gpios = <&gpio TEGRA_GPIO(L, 1) GPIO_ACTIVE_HIGH>;
+			linux,input-type = <EV_SW>;
+			linux,code = <SW_LID>;
+			linux,can-disable;
+			wakeup-source;
+		};
+	};
 
 	/* IDT V103 */
 	lvds-encoder {

--- a/arch/arm/boot/dts/tegra30-microsoft-surface-rt.dts
+++ b/arch/arm/boot/dts/tegra30-microsoft-surface-rt.dts
@@ -158,6 +158,14 @@
 				};
 			};
 		};
+		
+		nct1008: temperature-sensor@4c {
+			compatible = "onnn,nct1008";
+			reg = <0x4c>;
+			interrupt-parent = <&gpio>;
+			interrupts = <TEGRA_GPIO(DD, 5) IRQ_TYPE_EDGE_FALLING>;
+			#thermal-sensor-cells = <1>;
+		};
 	};
 
 	spi@7000da00 {

--- a/arch/arm/boot/dts/tegra30-microsoft-surface-rt.dts
+++ b/arch/arm/boot/dts/tegra30-microsoft-surface-rt.dts
@@ -206,7 +206,18 @@
 	};
 
 	usb-phy@7d000000 {
+		vbus-supply = <&usb_vbus_reg>;
 		status = "okay";
+	};
+	
+	usb_vbus_reg: regulator@103 {
+		compatible = "regulator-fixed";
+		regulator-name = "usb_vbus";
+		regulator-min-microvolt = <5000000>;
+		regulator-max-microvolt = <5000000>;
+		enable-active-high;
+		gpio = <&gpio TEGRA_GPIO(EE, 0) GPIO_ACTIVE_HIGH>;
+		gpio-open-drain;
 	};
 
 	backlight: backlight {

--- a/arch/arm/boot/dts/tegra30-microsoft-surface-rt.dts
+++ b/arch/arm/boot/dts/tegra30-microsoft-surface-rt.dts
@@ -190,6 +190,8 @@
 		vqmmc-supply = <&ldo5_reg>;
 		bus-width = <4>;
 		power-gpios = <&gpio TEGRA_GPIO(D, 7) GPIO_ACTIVE_HIGH>;
+		cd-gpios = <&gpio TEGRA_GPIO(I, 5) GPIO_ACTIVE_LOW>;
+		wp-gpios = <&gpio TEGRA_GPIO(T, 3) GPIO_ACTIVE_HIGH>;
 	};
 
 	/* internal 32/64GB eMMC - SDMMC-4 */


### PR DESCRIPTION
# uSD Card:
added CardDetection and WriteProtect gpio. They are the same pins as for Cardhu

# USB Vbus regulator
pulling the gpio EE0 Low disconnects all USB devices.

# Lid halleffect sensor
closing the lid triggers a hall effect sensor which will suspend the device after 3seconds.

# NCT1008 temperature sensor
Same sensor is used in Cardhu and Ouya.
lm-sensor read the correct temperatures

# tCover moved to efi.dts
tCover depends on a PMIC regulator and an I2C power up sequence provided by UEFI Firmware.
For APX tCover support further steps are necessary.



