### PR TITLE
WIP: ARM: tegra: surface-rt-efi: disable LP2

### DIFF
--- a/arch/arm/boot/dts/tegra30-microsoft-surface-rt-efi.dts
+++ b/arch/arm/boot/dts/tegra30-microsoft-surface-rt-efi.dts
@@ -13,6 +13,11 @@
 	/* L2 cache does not work yet */
 	/delete-node/ cache-controller@50043000;
 
+	/* CPU Idle does not work yet, disabling LP2 */
+	pmc@7000e400 {
+		/delete-property/ nvidia,suspend-mode;
+	};
+
 	ldo5_reg: tps65911-ldo5 {
 		compatible = "regulator-fixed";
 		regulator-name = "vddio_sdmmc";

--- a/arch/arm/boot/dts/tegra30-microsoft-surface-rt.dts
+++ b/arch/arm/boot/dts/tegra30-microsoft-surface-rt.dts
@@ -259,6 +259,7 @@
 			gpios = <&gpio TEGRA_GPIO(S, 5) GPIO_ACTIVE_HIGH>;
 			linux,code = <KEY_LEFTMETA>;
 			debounce-interval = <10>;
+			wakeup-source;
 		};
 
 		volume-down {


### PR DESCRIPTION
Now suspend partially (of course CPU voltage is enabled) works, although this is not enough to get working CPU idle. Device used to hang while suspending before this change.

BTW thanks for the tip.