### PR TITLE
WIP: ARM: tegra: surface-rt: add WiFi/BT

### DIFF
--- a/arch/arm/boot/dts/tegra30-microsoft-surface-rt.dts
+++ b/arch/arm/boot/dts/tegra30-microsoft-surface-rt.dts
@@ -12,9 +12,11 @@
 	aliases {
 		mmc0 = &sdmmc4; /* eMMC */
 		mmc1 = &sdmmc1; /* uSD slot */
+		mmc2 = &sdmmc3; /* WiFi */
 		rtc0 = &pmic;
 		rtc1 = "/rtc@7000e000";
-		serial0 = &uarta;
+		serial0 = &uarta; /* console */
+		serial1 = &uartc; /* Bluetooth */
 	};
 
 	chosen {
@@ -77,11 +79,31 @@
 				nvidia,tristate = <TEGRA_PIN_DISABLE>;
 				nvidia,enable-input = <TEGRA_PIN_DISABLE>;
 			};
+
+			wifi-interrupt {
+				nvidia,pins = "pu5";
+				nvidia,pull = <TEGRA_PIN_PULL_DOWN>;
+				nvidia,tristate = <TEGRA_PIN_DISABLE>;
+				nvidia,enable-input = <TEGRA_PIN_ENABLE>;
+			};
 		};
 	};
 
 	serial@70006000 {
 		status = "okay";
+	};
+
+	serial@70006200 {
+		status = "okay";
+		compatible = "nvidia,tegra30-hsuart";
+
+		nvidia,adjust-baud-rates = <0 9600 100>,
+					   <9600 115200 200>;
+
+		/* Marvell 88W8797 Bluetooth */
+		bluetooth {
+			compatible = "mrvl,88w8897";
+		};
 	};
 
 	pwm@7000a000 {
@@ -184,6 +206,33 @@
 		power-gpios = <&gpio TEGRA_GPIO(D, 7) GPIO_ACTIVE_HIGH>;
 		cd-gpios = <&gpio TEGRA_GPIO(I, 5) GPIO_ACTIVE_LOW>;
 		wp-gpios = <&gpio TEGRA_GPIO(T, 3) GPIO_ACTIVE_HIGH>;
+	};
+
+	mmc@78000400 {
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		status = "okay";
+
+		bus-width = <4>;
+		cap-power-off-card;
+		keep-power-in-suspend;
+		max-frequency = <50000000>;
+
+		assigned-clocks = <&tegra_car TEGRA30_CLK_SDMMC3>;
+		assigned-clock-parents = <&tegra_car TEGRA30_CLK_PLL_C>;
+		assigned-clock-rates = <50000000>;
+
+		mmc-pwrseq = <&brcm_wifi_pwrseq>;
+		vqmmc-supply = <&vqmmc_wifi>;
+
+		/* Marvell 88W8797 WiFi */
+		wifi@1 {
+			compatible = "marvell,sd8897";
+			reg = <1>;
+			interrupt-parent = <&gpio>;
+			interrupts = <TEGRA_GPIO(U, 5) IRQ_TYPE_LEVEL_HIGH>;
+		};
 	};
 
 	/* internal 32/64GB eMMC - SDMMC-4 */
@@ -318,6 +367,25 @@
 				};
 			};
 		};
+	};
+
+	brcm_wifi_pwrseq: wifi-pwrseq {
+		compatible = "mmc-pwrseq-simple";
+
+		clocks = <&tegra_pmc TEGRA_PMC_CLK_BLINK>;
+		clock-names = "ext_clock";
+
+		post-power-on-delay-ms = <300>;
+		power-off-delay-us = <300>;
+	};
+
+	vqmmc_wifi: vddio-wifi {
+		compatible = "regulator-fixed";
+		regulator-name = "vqmmc_wifi";
+		regulator-min-microvolt = <3300000>;
+		regulator-max-microvolt = <3300000>;
+		regulator-boot-on;
+		regulator-always-on;
 	};
 
 	vdd_pnl: vdd-panel {


### PR DESCRIPTION
WiFi asks for correct firmware and works with `linux-firmware-mrvl` installed.

Actual chip is 8797. Bluetooth boots with errors about missing firmware. It wants `helper_uart_3000000.bin` and when using the helper which i found for another chip it asks for `mrvl/uart8897_bt.bin` which is wrong (because of wrong helper?) and which i have not found as well as 8797. Also according to ACPI it has interrupt and some additional GPIO, but there are no those in Linux driver.