### PR TITLE
dt-bindigs: arm: tegra20: Acer A500 Picasso correct al8975 compatible

### DIFF
--- a/arch/arm/boot/dts/tegra20-acer-a500-picasso.dts
+++ b/arch/arm/boot/dts/tegra20-acer-a500-picasso.dts
@@ -543,7 +543,7 @@
 		status = "okay";
 
 		magnetometer@c {
-			compatible = "ak,ak8975";
+			compatible = "asahi-kasei,ak8975";
 			reg = <0x0c>;
 
 			interrupt-parent = <&gpio>;


### PR DESCRIPTION
"ak,ak8975" is not recognized by dt-bindings, "ak8975" is deprecated so
let's use supported "asahi-kasei,ak8975"

Signed-off-by: David Heidelberg <david@ixit.cz>